### PR TITLE
Work around incorrect maven-metadata.xml of net.minidev:json-smart

### DIFF
--- a/quickstart/backend/build.gradle.kts
+++ b/quickstart/backend/build.gradle.kts
@@ -43,6 +43,12 @@ dependencies {
     runtimeOnly(Deps.grpc.netty)
 
     testImplementation(Deps.springBoot.test)
+
+    constraints {
+        // maven-metadata.xml for net.minidev:json-smart now only contains one version 2.5.2 causing a resolution error
+        // TODO: Remove this constraint once the issue is resolved
+        implementation("net.minidev:json-smart:2.4.10")
+    }
 }
 
 repositories {


### PR DESCRIPTION
Description by Judy Wu (I'm observing the same):

While trying to make build the cn-quick start today, I noticed and error:

```
* What went wrong:
Could not resolve all files for configuration ':backend:runtimeClasspath'.
> Could not find any version that matches net.minidev:json-smart:[1.3.3,2.4.10].
  Versions that do not match: 2.5.2
  Searched in the following locations:
    - https://repo.maven.apache.org/maven2/net/minidev/json-smart/maven-metadata.xml
    - https://s01.oss.sonatype.org/content/repositories/snapshots/net/minidev/json-smart/maven-metadata.xml
  Required by:
      project :backend > org.springframework.boot:spring-boot-starter-oauth2-client:3.4.2 > org.springframework.security:spring-security-oauth2-client:6.4.2 > com.nimbusds:oauth2-oidc-sdk:9.43.4
```
after checking the dependency minidev:json-smart I saw the devs of above library made an update today for 2.5.2 and looks like the maven-metadata.xml now only contains one version 2.5.2 which seems to cause the error above.
