### PR TITLE
HOTFIX: fix OTel Agent wiring into backend-service

### DIFF
--- a/quickstart/compose.yaml
+++ b/quickstart/compose.yaml
@@ -328,6 +328,7 @@ services:
       AUTH_APP_USER_AUTHORIZATION_URI: "${AUTH_APP_USER_AUTHORIZATION_URI}"
       AUTH_APP_USER_JWK_SET_URI: "${AUTH_APP_USER_JWK_SET_URI}"
       LEDGER_API_ADMIN_USER: "${LEDGER_API_ADMIN_USER}"
+      JAVA_OPTS: "-javaagent:/otel-agent.jar"
     volumes:
       - ./backend/build/distributions/backend.tar:/backend.tar
       - ./backend/build/otel-agent/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar:/otel-agent.jar


### PR DESCRIPTION
`backend-service` already volume-mounts OTel Agent JAR file, sets up necessary env vars, however the JAR itself was 
not "propagated" into the JVM process