### PR TITLE
Add swagger-ui into docker network to allow viewing Canton JSON API V2 Open API spec in browser

### DIFF
--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -181,6 +181,17 @@ install-daml-sdk: ## Install the Daml SDK
 generate-NOTICES: ## Generate the NOTICES.txt file
 	./gradlew generateNotices
 
+.PHONY: start-swagger-ui
+start-swagger-ui:
+	docker compose -f docker/swagger/compose.yaml $(DOCKER_COMPOSE_ENVFILE) up -d || true
+
+.PHONY: stop-swagger-ui
+stop-swagger-ui:
+	docker compose -f docker/swagger/compose.yaml $(DOCKER_COMPOSE_ENVFILE) down || true
+
+.PHONY: restart-swagger-ui
+restart-swagger-ui: stop-swagger-ui start-swagger-ui
+
 # Help target
 .PHONY: help
 help: ## Show this help message
@@ -220,3 +231,5 @@ $(eval $(call open-url-target,open-sv-interface,http://sv.localhost:4000))
 $(eval $(call open-url-target,open-sv-scan,http://scan.localhost:4000))
 # open-app-user-wallet: ## Open the App User wallet UI in the active browser
 $(eval $(call open-url-target,open-app-user-wallet,http://wallet.localhost:2000))
+# open-swagger-ui: ## Open Swagger UI to view Canton JSON API V2 Open API in the active browser
+$(eval $(call open-url-target,open-swagger-ui,http://localhost:9080))

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -182,15 +182,9 @@ generate-NOTICES: ## Generate the NOTICES.txt file
 	./gradlew generateNotices
 
 .PHONY: start-swagger-ui
-start-swagger-ui:
-	docker compose -f docker/swagger/compose.yaml $(DOCKER_COMPOSE_ENVFILE) up -d || true
-
-.PHONY: stop-swagger-ui
-stop-swagger-ui:
-	docker compose -f docker/swagger/compose.yaml $(DOCKER_COMPOSE_ENVFILE) down || true
-
-.PHONY: restart-swagger-ui
-restart-swagger-ui: stop-swagger-ui start-swagger-ui
+start-swagger-ui: ## Start Swagger UI docker container for Canton JSON API OpenAPI Docs
+	@echo "Starting Swagger UI on http://localhost:9080"
+	docker compose -f docker/swagger/compose.yaml $(DOCKER_COMPOSE_ENVFILE) up || true
 
 # Help target
 .PHONY: help

--- a/quickstart/compose.yaml
+++ b/quickstart/compose.yaml
@@ -453,6 +453,7 @@ services:
       - ./config/nginx/app-provider/frontend.conf:/etc/nginx/conf.d/default.conf
       - ./config/nginx/app-provider/common-backend-proxy-settings.conf:/etc/nginx/common-backend-proxy-settings.conf
       - ./config/nginx/app-provider/wallet.conf:/etc/nginx/conf.d/wallet.conf
+      - ./config/nginx/app-provider/swagger.conf:/etc/nginx/conf.d/swagger.conf
     ports:
       - "${APP_PROVIDER_UI_PORT}:80"
     depends_on:

--- a/quickstart/config/nginx/app-provider/swagger.conf
+++ b/quickstart/config/nginx/app-provider/swagger.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name swagger.localhost;
+    location /docs/openapi {
+        proxy_pass http://participant-app-provider:7575/docs/openapi;
+        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS';
+        add_header Access-Control-Allow-Headers 'Origin, Content-Type, Accept';
+    }
+}

--- a/quickstart/docker/swagger/compose.yaml
+++ b/quickstart/docker/swagger/compose.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Description: Docker compose file for running Swagger UI with the cnrc-transfer-instruction OpenAPI specification.
+# Usage: docker-compose up
+---
+networks:
+  quickstart:
+    external: true
+    name: ${DOCKER_NETWORK}
+
+services:
+  swagger-ui:
+    image: swaggerapi/swagger-ui
+    ports:
+      - "9080:8080"
+    environment:
+      - URL=http://swagger.localhost:3000/docs/openapi
+    networks:
+      - ${DOCKER_NETWORK}


### PR DESCRIPTION
Purpose as titled
The PR is aimed to address the issue proposed [here](https://github.com/digital-asset/cn-quickstart/issues/42)