### PR TITLE
Add docker resource limits and controls for all services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ gradle-app.setting
 
 # backups
 *.bak
+
+# MacOS
+.DS_Store

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -131,10 +131,6 @@ restart: stop start ## Restart the application
 status: ## Show status of Docker containers
 	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) ps)
 
-.PHONY: status
-services: ## List all services in compose template
-	@$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) ps --services)
-
 .PHONY: compose-config
 compose-config:
 	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) config)

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -16,11 +16,6 @@ else
 FIRST_RUN_DEPENDENCY := first-run-setup
 endif
 
-ifeq ($(RESOURCE_CONTROL),true)
-RESOURCE_CONFIG := -f docker/resource-control.yaml
-else
-RESOURCE_CONFIG :=
-endif
 # Set default goal to 'help' if no target is specified
 .DEFAULT_GOAL := help
 
@@ -32,7 +27,7 @@ KERNEL_NAME := $(shell uname -s)
 DOCKER_COMPOSE_ENVFILE := --env-file .env.local --env-file .env
 DOCKER_COMPOSE_FILES := -f compose.yaml
 
-# default to add resource constraints for Quickstart default stack.
+# Default to adding resource constraints for Quickstart compose stack.
 RESOURCE_CONSTRAINTS ?= true
 
 ifeq ($(RESOURCE_CONSTRAINTS),true)

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -43,9 +43,9 @@ endif
 
 
 ifeq ($(KERNEL_NAME), Darwin)
-DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-darwin.yaml -f docker/o11y/compose.yaml $(RESOURCE_CONSTRAINT_CONFIG)
+DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-darwin.yaml -f docker/o11y/compose.yaml
 else ifeq ($(KERNEL_NAME), Linux)
-DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-linux.yaml -f docker/o11y/compose.yaml $(RESOURCE_CONSTRAINT_CONFIG)
+DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-linux.yaml -f docker/o11y/compose.yaml
 else
 DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/compose.yaml
 endif
@@ -100,7 +100,7 @@ build-daml: ## Build the Daml model
 
 .PHONY: build-docker-images
 build-docker-images:
-	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} build)
+	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) build)
 
 .PHONY: create-app-install-request
 create-app-install-request: ## Submit an App Install Request from the App User participant node
@@ -117,12 +117,12 @@ restart-frontend: build-frontend ## Build and start the application
 # Run targets
 .PHONY: start
 start: $(FIRST_RUN_DEPENDENCY) build ## Start the application, and observability services if enabled
-	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} up -d)
+	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) up -d)
 
 
 .PHONY: stop
 stop: ## Stop the application and observability services
-	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} down)
+	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) down)
 
 .PHONY: stop-application
 stop-application: ## Stop the application, leaving observability services running
@@ -134,15 +134,15 @@ restart: stop start ## Restart the application
 # Utility targets
 .PHONY: status
 status: ## Show status of Docker containers
-	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} ps)
+	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) ps)
 
 .PHONY: status
 services: ## List all services in compose template
-	@$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} ps --services)
+	@$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) ps --services)
 
 .PHONY: compose-config
 compose-config:
-	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} config)
+	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) config)
 
 .PHONY: logs
 logs: ## Show logs of Docker containers
@@ -203,7 +203,7 @@ clean: ## Clean the build artifacts
 
 .PHONY: clean-docker
 clean-docker: clean-shell clean-console-app-provider clean-console-app-user ## Stop and remove application Docker containers and volumes
-	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} down -v)
+	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) down -v)
 
 .PHONY: clean-application
 clean-application: ## like clean-docker, but leave observability services running

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -16,6 +16,11 @@ else
 FIRST_RUN_DEPENDENCY := first-run-setup
 endif
 
+ifeq ($(RESOURCE_CONTROL),true)
+RESOURCE_CONFIG := -f docker/resource-control.yaml
+else
+RESOURCE_CONFIG :=
+endif
 # Set default goal to 'help' if no target is specified
 .DEFAULT_GOAL := help
 
@@ -28,9 +33,9 @@ DOCKER_COMPOSE_ENVFILE := --env-file .env.local --env-file .env
 DOCKER_COMPOSE_FILES := -f compose.yaml
 
 ifeq ($(KERNEL_NAME), Darwin)
-DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-darwin.yaml -f docker/o11y/compose.yaml
+DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-darwin.yaml -f docker/o11y/compose.yaml $(RESOURCE_CONFIG)
 else ifeq ($(KERNEL_NAME), Linux)
-DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-linux.yaml -f docker/o11y/compose.yaml
+DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-linux.yaml -f docker/o11y/compose.yaml $(RESOURCE_CONFIG)
 else
 DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/compose.yaml
 endif
@@ -119,7 +124,15 @@ restart: stop start ## Restart the application
 # Utility targets
 .PHONY: status
 status: ## Show status of Docker containers
-	$(call docker-compose, ps)
+	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} ps)
+
+.PHONY: status
+services: ## List all services in compose template
+	@$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} ps --services)
+
+.PHONY: compose-config
+compose-config:
+	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} config)
 
 .PHONY: logs
 logs: ## Show logs of Docker containers

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -32,10 +32,20 @@ KERNEL_NAME := $(shell uname -s)
 DOCKER_COMPOSE_ENVFILE := --env-file .env.local --env-file .env
 DOCKER_COMPOSE_FILES := -f compose.yaml
 
+# default to add resource constraints for Quickstart default stack.
+RESOURCE_CONSTRAINTS ?= true
+
+ifeq ($(RESOURCE_CONSTRAINTS),true)
+RESOURCE_CONSTRAINT_CONFIG := -f docker/resource-constraints.yaml
+else
+RESOURCE_CONSTRAINT_CONFIG :=
+endif
+
+
 ifeq ($(KERNEL_NAME), Darwin)
-DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-darwin.yaml -f docker/o11y/compose.yaml $(RESOURCE_CONFIG)
+DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-darwin.yaml -f docker/o11y/compose.yaml $(RESOURCE_CONSTRAINT_CONFIG)
 else ifeq ($(KERNEL_NAME), Linux)
-DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-linux.yaml -f docker/o11y/compose.yaml $(RESOURCE_CONFIG)
+DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/cadvisor-linux.yaml -f docker/o11y/compose.yaml $(RESOURCE_CONSTRAINT_CONFIG)
 else
 DOCKER_COMPOSE_OBSERVABILITY_FILES := -f docker/o11y/compose.yaml
 endif

--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -28,9 +28,9 @@ DOCKER_COMPOSE_ENVFILE := --env-file .env.local --env-file .env
 DOCKER_COMPOSE_FILES := -f compose.yaml
 
 # Default to adding resource constraints for Quickstart compose stack.
-RESOURCE_CONSTRAINTS ?= true
+RESOURCE_CONSTRAINTS_ENABLED ?= true
 
-ifeq ($(RESOURCE_CONSTRAINTS),true)
+ifeq ($(RESOURCE_CONSTRAINTS_ENABLED),true)
 RESOURCE_CONSTRAINT_CONFIG := -f docker/resource-constraints.yaml
 else
 RESOURCE_CONSTRAINT_CONFIG :=

--- a/quickstart/compose.yaml
+++ b/quickstart/compose.yaml
@@ -60,7 +60,7 @@ services:
 ###############################################################################################################
 ### Common Services
 ###############################################################################################################
-  postgres:
+  keycloak-postgres:
     image: postgres:14
     container_name: keycloak-postgres
     environment:
@@ -101,7 +101,7 @@ services:
       KC_DB: postgres
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: password
-      KC_DB_URL_HOST: postgres
+      KC_DB_URL_HOST: keycloak-postgres
       KC_DB_URL_DATABASE: keycloakdb
       KC_HEALTH_ENABLED: true
     healthcheck:

--- a/quickstart/compose.yaml
+++ b/quickstart/compose.yaml
@@ -147,7 +147,7 @@ services:
     command:
       - postgres
       - -c
-      - max_connections=8000
+      - max_connections=1000
     logging: *default-logging
 
   participant-app-user:
@@ -413,7 +413,7 @@ services:
     command:
       - postgres
       - -c
-      - max_connections=8000
+      - max_connections=1000
     logging: *default-logging
 
   participant-app-provider:
@@ -647,7 +647,7 @@ services:
     command:
       - postgres
       - -c
-      - max_connections=8000
+      - max_connections=1000
     logging: *default-logging
     networks:
       - ${DOCKER_NETWORK}

--- a/quickstart/docker/canton-console/compose.yaml
+++ b/quickstart/docker/canton-console/compose.yaml
@@ -10,10 +10,12 @@ networks:
 services:
   canton-console-app-provider:
     image: "${IMAGE_REPO}canton:${IMAGE_TAG}"
+    mem_limit: 1gb
     volumes:
       - ../../config/canton-console/app.conf:/app/app.conf
       - ../../docker/canton-console/entrypoint.sh:/app/entrypoint.sh
     environment:
+      - _JAVA_OPTIONS=-XX:+UseContainerSupport -XX:-UseCompressedOops
       - PARTICIPANT_LEDGER_API_PORT=${PARTICIPANT_LEDGER_API_PORT}
       - PARTICIPANT_ADMIN_API_PORT=${PARTICIPANT_ADMIN_API_PORT}
       - LEDGER_API_ADDRESS=participant-app-provider
@@ -28,10 +30,12 @@ services:
 
   canton-console-app-user:
     image: "${IMAGE_REPO}canton:${IMAGE_TAG}"
+    mem_limit: 1gb
     volumes:
       - ../../config/canton-console/app.conf:/app/app.conf
       - ../../docker/canton-console/entrypoint.sh:/app/entrypoint.sh
     environment:
+      - _JAVA_OPTIONS=-XX:+UseContainerSupport -XX:-UseCompressedOops
       - PARTICIPANT_LEDGER_API_PORT=${PARTICIPANT_LEDGER_API_PORT}
       - PARTICIPANT_ADMIN_API_PORT=${PARTICIPANT_ADMIN_API_PORT}
       - LEDGER_API_ADDRESS=participant-app-user

--- a/quickstart/docker/daml-shell/compose.yaml
+++ b/quickstart/docker/daml-shell/compose.yaml
@@ -10,7 +10,9 @@ networks:
 services:
   daml-shell:
     image: ${SHELL_IMAGE}:${SHELL_VERSION}
+    mem_limit: 1gb
     environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
       DAML_SHELL_POSTGRES_HOST: "${SCRIBE_POSTGRES_HOST}"
       DAML_SHELL_POSTGRES_USERNAME: "${SCRIBE_POSTGRES_USER}"
       DAML_SHELL_POSTGRES_PASSWORD: "${SCRIBE_POSTGRES_PASSWORD}"

--- a/quickstart/docker/daml-shell/compose.yaml
+++ b/quickstart/docker/daml-shell/compose.yaml
@@ -12,7 +12,7 @@ services:
     image: ${SHELL_IMAGE}:${SHELL_VERSION}
     mem_limit: 512mb
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms256m -Xmx384m"
       DAML_SHELL_POSTGRES_HOST: "${SCRIBE_POSTGRES_HOST}"
       DAML_SHELL_POSTGRES_USERNAME: "${SCRIBE_POSTGRES_USER}"
       DAML_SHELL_POSTGRES_PASSWORD: "${SCRIBE_POSTGRES_PASSWORD}"

--- a/quickstart/docker/daml-shell/compose.yaml
+++ b/quickstart/docker/daml-shell/compose.yaml
@@ -10,7 +10,7 @@ networks:
 services:
   daml-shell:
     image: ${SHELL_IMAGE}:${SHELL_VERSION}
-    mem_limit: 1gb
+    mem_limit: 512mb
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
       DAML_SHELL_POSTGRES_HOST: "${SCRIBE_POSTGRES_HOST}"

--- a/quickstart/docker/o11y/compose.yaml
+++ b/quickstart/docker/o11y/compose.yaml
@@ -11,6 +11,7 @@ services:
     image: ${OTEL_COLLECTOR_IMAGE}:${OTEL_COLLECTOR_VERSION}
     container_name: otel-collector
     hostname: otel-collector
+    mem_limit: 1gb
     ports:
       - "${OTEL_COLLECTOR_FLUENTD_PORT}:${OTEL_COLLECTOR_FLUENTD_PORT}"
     command:
@@ -37,6 +38,7 @@ services:
     image: ${PROMETHEUS_IMAGE}:${PROMETHEUS_VERSION}
     container_name: prometheus
     hostname: prometheus
+    mem_limit: 256mb
     command:
       - --config.file=/etc/prometheus/config.yaml
       - --web.enable-admin-api
@@ -57,6 +59,7 @@ services:
     image: ${LOKI_IMAGE}:${LOKI_VERSION}
     container_name: loki
     hostname: loki
+    mem_limit: 512mb
     command:
       - --config.file=/etc/loki/config.yaml
       - --config.expand-env=true
@@ -73,6 +76,7 @@ services:
     image: ${TEMPO_IMAGE}:${TEMPO_VERSION}
     container_name: tempo
     hostname: tempo
+    mem_limit: 1g
     command:
       - --config.file=/etc/tempo/config.yaml
       - --config.expand-env=true
@@ -91,6 +95,7 @@ services:
     image: ${GRAFANA_IMAGE}:${GRAFANA_VERSION}
     container_name: grafana
     hostname: grafana
+    mem_limit: 256mb
     environment:
       LOKI_PORT: ${LOKI_HTTP_PORT}
       PROMETHEUS_PORT: ${PROMETHEUS_HTTP_PORT}
@@ -113,6 +118,7 @@ services:
     image: ${CADVISOR_IMAGE}:${CADVISOR_VERSION}
     container_name: cadvisor
     hostname: cadvisor
+    mem_limit: 256mb
     command:
       - --store_container_labels=false
       - -docker_only
@@ -126,6 +132,7 @@ services:
     image: ${NGINX_EXPORTER_IMAGE}:${NGINX_EXPORTER_VERSION}
     container_name: nginx-app-user-metrics
     hostname: nginx-app-user-metrics
+    mem_limit: 32mb
     command:
       - --nginx.scrape-uri=http://nginx-app-user/status
       - --web.listen-address=:${NGINX_EXPORTER_METRICS_PORT}
@@ -138,6 +145,7 @@ services:
     image: ${NGINX_EXPORTER_IMAGE}:${NGINX_EXPORTER_VERSION}
     container_name: nginx-app-provider-metrics
     hostname: nginx-app-provider-metrics
+    mem_limit: 32mb
     command:
       - --nginx.scrape-uri=http://nginx-app-provider/status
       - --web.listen-address=:${NGINX_EXPORTER_METRICS_PORT}
@@ -150,6 +158,7 @@ services:
     image: ${NGINX_EXPORTER_IMAGE}:${NGINX_EXPORTER_VERSION}
     container_name: nginx-sv-metrics
     hostname: nginx-sv-metrics
+    mem_limit: 32mb
     command:
       - --nginx.scrape-uri=http://nginx-sv/status
       - --web.listen-address=:${NGINX_EXPORTER_METRICS_PORT}
@@ -162,6 +171,7 @@ services:
     image: ${POSTGRES_EXPORTER_IMAGE}:${POSTGRES_EXPORTER_VERSION}
     container_name: postgres-splice-app-user-metrics
     hostname: postgres-splice-app-user-metrics
+    mem_limit: 32mb
     command:
       - --web.listen-address=:${POSTGRES_EXPORTER_METRICS_PORT}
     environment:
@@ -177,6 +187,7 @@ services:
     image: ${POSTGRES_EXPORTER_IMAGE}:${POSTGRES_EXPORTER_VERSION}
     container_name: postgres-splice-app-provider-metrics
     hostname: postgres-splice-app-provider-metrics
+    mem_limit: 32mb
     command:
       - --web.listen-address=:${POSTGRES_EXPORTER_METRICS_PORT}
     environment:
@@ -192,6 +203,7 @@ services:
     image: ${POSTGRES_EXPORTER_IMAGE}:${POSTGRES_EXPORTER_VERSION}
     container_name: postgres-splice-sv-metrics
     hostname: postgres-splice-sv-metrics
+    mem_limit: 32mb
     command:
       - --web.listen-address=:${POSTGRES_EXPORTER_METRICS_PORT}
     environment:

--- a/quickstart/docker/resource-constraints.yaml
+++ b/quickstart/docker/resource-constraints.yaml
@@ -5,13 +5,13 @@ services:
   backend-service:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx700m"
   backend-service-auto-config:
     mem_limit: 32mb
   global-synchronizer:
-    mem_limit: 2g
+    mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx512m"
   nginx-keycloak:
     mem_limit: 32mb
   nginx-app-provider:
@@ -63,13 +63,15 @@ services:
   sv-web-ui:
     mem_limit: 512mb
   validator-app-provider:
-    mem_limit: 2g
+    mem_limit: 1g
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
   validator-app-provider-auto-config:
     mem_limit: 32mb
   validator-app-user:
-    mem_limit: 2g
+    mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
   validator-app-user-auto-config:
     mem_limit: 32mb
   validator-sv:

--- a/quickstart/docker/resource-constraints.yaml
+++ b/quickstart/docker/resource-constraints.yaml
@@ -21,21 +21,23 @@ services:
   nginx-sv:
     mem_limit: 32mb
   keycloak:
-    mem_limit: 3g
+    mem_limit: 1g
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx700m"
   keycloak-postgres:
     mem_limit: 256mb
   participant-app-provider:
-    mem_limit: 4g
+    mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
   participant-app-user:
-    mem_limit: 4g
+    mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
   participant-sv:
-    mem_limit: 4g
+    mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
   postgres-splice:
     mem_limit: 512mb
   postgres-splice-app-provider:
@@ -47,17 +49,17 @@ services:
   pqs:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops-Xms512m -Xmx768m"
   scan:
-    mem_limit: 2g
+    mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
   scan-web-ui:
     mem_limit: 256mb
   sv-app:
-    mem_limit: 2g
+    mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
   sv-web-ui:
     mem_limit: 512mb
   validator-app-provider:
@@ -67,13 +69,13 @@ services:
   validator-app-user:
     mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
   validator-app-user-auto-config:
     mem_limit: 32mb
   validator-sv:
     mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
   wallet-web-ui-app-provider:
     mem_limit: 256mb
   wallet-web-ui-app-user:

--- a/quickstart/docker/resource-constraints.yaml
+++ b/quickstart/docker/resource-constraints.yaml
@@ -49,7 +49,7 @@ services:
   pqs:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops-Xms512m -Xmx768m"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
   scan:
     mem_limit: 1g
     environment:

--- a/quickstart/docker/resource-constraints.yaml
+++ b/quickstart/docker/resource-constraints.yaml
@@ -1,3 +1,6 @@
+## This file is used to set and control resource constraints for all essential services defined
+## in the Quickstart template, These values should be adjusted carefully as it will impact the
+## baseline resource requirements for the project.
 services:
   await-onboarding-done:
     mem_limit: 32mb
@@ -8,7 +11,7 @@ services:
   global-synchronizer:
     mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"    
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   nginx-app-provider:
     mem_limit: 32mb
   nginx-app-user:

--- a/quickstart/docker/resource-constraints.yaml
+++ b/quickstart/docker/resource-constraints.yaml
@@ -2,8 +2,6 @@
 ## in the Quickstart template, These values should be adjusted carefully as it will impact the
 ## baseline resource requirements for the project.
 services:
-  await-onboarding-done:
-    mem_limit: 32mb
   backend-service:
     mem_limit: 1g
     environment:
@@ -12,13 +10,17 @@ services:
     mem_limit: 2g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+  nginx-keycloak:
+    mem_limit: 32mb
   nginx-app-provider:
     mem_limit: 32mb
   nginx-app-user:
     mem_limit: 32mb
   nginx-sv:
     mem_limit: 32mb
-  oauth:
+  keycloak:
+    mem_limit: 2g
+  keycloak-postgres:
     mem_limit: 256mb
   participant-app-provider:
     mem_limit: 4g
@@ -58,10 +60,14 @@ services:
     mem_limit: 512mb
   validator-app-provider:
     mem_limit: 2g
+  validator-app-provider-auto-config:
+    mem_limit: 32mb
   validator-app-user:
     mem_limit: 2g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+  validator-app-user-auto-config:
+    mem_limit: 32mb
   validator-sv:
     mem_limit: 2g
     environment:

--- a/quickstart/docker/resource-constraints.yaml
+++ b/quickstart/docker/resource-constraints.yaml
@@ -21,7 +21,7 @@ services:
   nginx-sv:
     mem_limit: 32mb
   keycloak:
-    mem_limit: 2g
+    mem_limit: 3g
   keycloak-postgres:
     mem_limit: 256mb
   participant-app-provider:

--- a/quickstart/docker/resource-constraints.yaml
+++ b/quickstart/docker/resource-constraints.yaml
@@ -6,6 +6,8 @@ services:
     mem_limit: 1g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+  backend-service-auto-config:
+    mem_limit: 32mb
   global-synchronizer:
     mem_limit: 2g
     environment:

--- a/quickstart/docker/resource-constraints.yaml
+++ b/quickstart/docker/resource-constraints.yaml
@@ -5,13 +5,13 @@ services:
   backend-service:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx700m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx700m"
   backend-service-auto-config:
     mem_limit: 32mb
   global-synchronizer:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx512m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx512m"
   nginx-keycloak:
     mem_limit: 32mb
   nginx-app-provider:
@@ -23,21 +23,21 @@ services:
   keycloak:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx700m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx700m"
   keycloak-postgres:
     mem_limit: 256mb
   participant-app-provider:
     mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx1536m"
   participant-app-user:
     mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx1536m"
   participant-sv:
     mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx1536m"
   postgres-splice:
     mem_limit: 512mb
   postgres-splice-app-provider:
@@ -49,35 +49,35 @@ services:
   pqs:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx768m"
   scan:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx768m"
   scan-web-ui:
     mem_limit: 256mb
   sv-app:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx768m"
   sv-web-ui:
     mem_limit: 512mb
   validator-app-provider:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx768m"
   validator-app-provider-auto-config:
     mem_limit: 32mb
   validator-app-user:
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx768m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx768m"
   validator-app-user-auto-config:
     mem_limit: 32mb
   validator-sv:
     mem_limit: 2g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -Xms512m -Xmx1536m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx1536m"
   wallet-web-ui-app-provider:
     mem_limit: 256mb
   wallet-web-ui-app-user:

--- a/quickstart/docker/resource-control.yaml
+++ b/quickstart/docker/resource-control.yaml
@@ -49,20 +49,20 @@ services:
     mem_limit: 256mb
   sv-app:
     mem_limit: 2g
-    # environment:
-    #   _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   sv-web-ui:
     mem_limit: 512mb
   validator-app-provider:
     mem_limit: 2g
   validator-app-user:
     mem_limit: 2g
-    # environment:
-    #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   validator-sv:
     mem_limit: 2g
-    # environment:
-    #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   wallet-web-ui-app-provider:
     mem_limit: 256mb
   wallet-web-ui-app-user:

--- a/quickstart/docker/resource-control.yaml
+++ b/quickstart/docker/resource-control.yaml
@@ -1,132 +1,95 @@
 services:
   await-onboarding-done:
-    #cpus: 1
     mem_limit: 32mb
   backend-service:
-    #cpus: 1
     mem_limit: 1g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   cadvisor:
-    #cpus: 1
     mem_limit: 256mb
   global-synchronizer:
-    #cpus: 1
     mem_limit: 2g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"    
   grafana:
-    #cpus: 1
     mem_limit: 256mb
   loki:
-    #cpus: 1
     mem_limit: 512mb
   nginx-app-provider:
-    #cpus: 1
     mem_limit: 32mb
   nginx-app-provider-metrics:
-    #cpus: 1
     mem_limit: 32mb
   nginx-app-user:
-    #cpus: 1
     mem_limit: 32mb
   nginx-app-user-metrics:
-    #cpus: 1
     mem_limit: 32mb
   nginx-sv:
-    #cpus: 1
     mem_limit: 32mb
   nginx-sv-metrics:
-    #cpus: 1
     mem_limit: 32mb
   oauth:
-    #cpus: 1
     mem_limit: 256mb
   otel-collector:
-    #cpus: 1
     mem_limit: 1gb
   participant-app-provider:
-    #cpus: 1
     mem_limit: 4g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   participant-app-user:
-    #cpus: 1
     mem_limit: 4g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   participant-sv:
-    #cpus: 1
     mem_limit: 4g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   postgres-splice:
-    #cpus: 1
     mem_limit: 512mb
   postgres-splice-app-provider:
-    #cpus: 1
     mem_limit: 512mb
   postgres-splice-app-provider-metrics:
-    #cpus: 1
     mem_limit: 32mb
   postgres-splice-app-user:
-    #cpus: 1
     mem_limit: 512mb
   postgres-splice-app-user-metrics:
-    #cpus: 1
     mem_limit: 32mb
   postgres-splice-sv:
-    #cpus: 1
     mem_limit: 512mb
   postgres-splice-sv-metrics:
-    #cpus: 1
     mem_limit: 32mb
   pqs:
-    #cpus: 1
     mem_limit: 1g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   prometheus:
-    #cpus: 1
     mem_limit: 256mb
   scan:
-    #cpus: 1
     mem_limit: 2g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   scan-web-ui:
-    #cpus: 1
     mem_limit: 256mb
   sv-app:
-    #cpus: 1
     mem_limit: 2g
     # environment:
     #   _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   sv-web-ui:
-    #cpus: 1
     mem_limit: 512mb
   tempo:
-    #cpus: 1
     mem_limit: 1g
   validator-app-provider:
-    #cpus: 1
     mem_limit: 2g
   validator-app-user:
-    #cpus: 1
     mem_limit: 2g
     # environment:
     #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   validator-sv:
-    #cpus: 1
     mem_limit: 2g
     # environment:
     #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   wallet-web-ui-app-provider:
-    #cpus: 1
     mem_limit: 256mb
   wallet-web-ui-app-user:
-    #cpus: 1
     mem_limit: 256mb
   wallet-web-ui-sv:
-    #cpus: 1
     mem_limit: 256mb

--- a/quickstart/docker/resource-control.yaml
+++ b/quickstart/docker/resource-control.yaml
@@ -4,9 +4,9 @@ services:
     mem_limit: 32mb
   backend-service:
     #cpus: 1
-    mem_limit: 512mb
+    mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   cadvisor:
     #cpus: 1
     mem_limit: 256mb
@@ -47,16 +47,19 @@ services:
     mem_limit: 1gb
   participant-app-provider:
     #cpus: 1
-    mem_limit: 5g
-
+    mem_limit: 4g
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   participant-app-user:
     #cpus: 1
-    mem_limit: 5g
-
+    mem_limit: 4g
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   participant-sv:
     #cpus: 1
-    mem_limit: 5g
-
+    mem_limit: 4g
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   postgres-splice:
     #cpus: 1
     mem_limit: 512mb
@@ -77,12 +80,12 @@ services:
     mem_limit: 512mb
   postgres-splice-sv-metrics:
     #cpus: 1
-    mem_limit: 512mb
+    mem_limit: 32mb
   pqs:
     #cpus: 1
     mem_limit: 1g
     environment:
-      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   prometheus:
     #cpus: 1
     mem_limit: 256mb
@@ -90,15 +93,15 @@ services:
     #cpus: 1
     mem_limit: 2g
     environment:
-      JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport"
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   scan-web-ui:
     #cpus: 1
-    mem_limit: 1g
+    mem_limit: 256mb
   sv-app:
     #cpus: 1
     mem_limit: 2g
     # environment:
-    #   _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+    #   _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   sv-web-ui:
     #cpus: 1
     mem_limit: 512mb
@@ -112,12 +115,12 @@ services:
     #cpus: 1
     mem_limit: 2g
     # environment:
-    #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+    #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   validator-sv:
     #cpus: 1
     mem_limit: 2g
     # environment:
-    #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+    #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   wallet-web-ui-app-provider:
     #cpus: 1
     mem_limit: 256mb

--- a/quickstart/docker/resource-control.yaml
+++ b/quickstart/docker/resource-control.yaml
@@ -5,32 +5,18 @@ services:
     mem_limit: 1g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
-  cadvisor:
-    mem_limit: 256mb
   global-synchronizer:
     mem_limit: 2g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"    
-  grafana:
-    mem_limit: 256mb
-  loki:
-    mem_limit: 512mb
   nginx-app-provider:
-    mem_limit: 32mb
-  nginx-app-provider-metrics:
     mem_limit: 32mb
   nginx-app-user:
     mem_limit: 32mb
-  nginx-app-user-metrics:
-    mem_limit: 32mb
   nginx-sv:
-    mem_limit: 32mb
-  nginx-sv-metrics:
     mem_limit: 32mb
   oauth:
     mem_limit: 256mb
-  otel-collector:
-    mem_limit: 1gb
   participant-app-provider:
     mem_limit: 4g
     environment:
@@ -47,22 +33,14 @@ services:
     mem_limit: 512mb
   postgres-splice-app-provider:
     mem_limit: 512mb
-  postgres-splice-app-provider-metrics:
-    mem_limit: 32mb
   postgres-splice-app-user:
     mem_limit: 512mb
-  postgres-splice-app-user-metrics:
-    mem_limit: 32mb
   postgres-splice-sv:
     mem_limit: 512mb
-  postgres-splice-sv-metrics:
-    mem_limit: 32mb
   pqs:
     mem_limit: 1g
     environment:
       _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
-  prometheus:
-    mem_limit: 256mb
   scan:
     mem_limit: 2g
     environment:
@@ -75,8 +53,6 @@ services:
     #   _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops"
   sv-web-ui:
     mem_limit: 512mb
-  tempo:
-    mem_limit: 1g
   validator-app-provider:
     mem_limit: 2g
   validator-app-user:

--- a/quickstart/docker/resource-control.yaml
+++ b/quickstart/docker/resource-control.yaml
@@ -1,0 +1,129 @@
+services:
+  await-onboarding-done:
+    #cpus: 1
+    mem_limit: 32mb
+  backend-service:
+    #cpus: 1
+    mem_limit: 512mb
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+  cadvisor:
+    #cpus: 1
+    mem_limit: 256mb
+  global-synchronizer:
+    #cpus: 1
+    mem_limit: 2g
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"    
+  grafana:
+    #cpus: 1
+    mem_limit: 256mb
+  loki:
+    #cpus: 1
+    mem_limit: 512mb
+  nginx-app-provider:
+    #cpus: 1
+    mem_limit: 32mb
+  nginx-app-provider-metrics:
+    #cpus: 1
+    mem_limit: 32mb
+  nginx-app-user:
+    #cpus: 1
+    mem_limit: 32mb
+  nginx-app-user-metrics:
+    #cpus: 1
+    mem_limit: 32mb
+  nginx-sv:
+    #cpus: 1
+    mem_limit: 32mb
+  nginx-sv-metrics:
+    #cpus: 1
+    mem_limit: 32mb
+  oauth:
+    #cpus: 1
+    mem_limit: 256mb
+  otel-collector:
+    #cpus: 1
+    mem_limit: 1gb
+  participant-app-provider:
+    #cpus: 1
+    mem_limit: 5g
+
+  participant-app-user:
+    #cpus: 1
+    mem_limit: 5g
+
+  participant-sv:
+    #cpus: 1
+    mem_limit: 5g
+
+  postgres-splice:
+    #cpus: 1
+    mem_limit: 512mb
+  postgres-splice-app-provider:
+    #cpus: 1
+    mem_limit: 512mb
+  postgres-splice-app-provider-metrics:
+    #cpus: 1
+    mem_limit: 32mb
+  postgres-splice-app-user:
+    #cpus: 1
+    mem_limit: 512mb
+  postgres-splice-app-user-metrics:
+    #cpus: 1
+    mem_limit: 32mb
+  postgres-splice-sv:
+    #cpus: 1
+    mem_limit: 512mb
+  postgres-splice-sv-metrics:
+    #cpus: 1
+    mem_limit: 512mb
+  pqs:
+    #cpus: 1
+    mem_limit: 1g
+    environment:
+      _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+  prometheus:
+    #cpus: 1
+    mem_limit: 256mb
+  scan:
+    #cpus: 1
+    mem_limit: 2g
+    environment:
+      JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport"
+  scan-web-ui:
+    #cpus: 1
+    mem_limit: 1g
+  sv-app:
+    #cpus: 1
+    mem_limit: 2g
+    # environment:
+    #   _JAVA_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+  sv-web-ui:
+    #cpus: 1
+    mem_limit: 512mb
+  tempo:
+    #cpus: 1
+    mem_limit: 1g
+  validator-app-provider:
+    #cpus: 1
+    mem_limit: 2g
+  validator-app-user:
+    #cpus: 1
+    mem_limit: 2g
+    # environment:
+    #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+  validator-sv:
+    #cpus: 1
+    mem_limit: 2g
+    # environment:
+    #   JAVA_TOOL_OPTIONS: "-XX:+UseContainerSupport -XX:-UseCompressedOops -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+  wallet-web-ui-app-provider:
+    #cpus: 1
+    mem_limit: 256mb
+  wallet-web-ui-app-user:
+    #cpus: 1
+    mem_limit: 256mb
+  wallet-web-ui-sv:
+    #cpus: 1
+    mem_limit: 256mb

--- a/quickstart/docker/swagger/compose.yaml
+++ b/quickstart/docker/swagger/compose.yaml
@@ -12,6 +12,7 @@ networks:
 services:
   swagger-ui:
     image: swaggerapi/swagger-ui
+    mem_limit: 128mb
     ports:
       - "9080:8080"
     environment:


### PR DESCRIPTION
Add default memory limits for all docker compose services. For java based services add additional JVM controls. Relates to #56.

## Changes
- add `quickstart/docker/resource-constraints.yaml` for defining all resource constraints and controls for services defined in `quickstart/compose.yaml`
- add logic to `quickstart/Makefile` to default to adding `-f docker/resource-constraints.yaml`  to docker compose commands when `RESOURCE_CONSTRAINTS_ENABLED` is set to `true`. The `RESOURCE_CONSTRAINTS_ENABLED` variable is set to `true` by default. This has been done to allow engineers to disable adding resource constraints if we need to trouble shoot stability/OOM issues
- add resource constraints to `quickstart/docker/o11y/compose.yaml` for all observability components
- add resource constraints to `quickstart/docker/daml-shell/compose.yaml` for daml-shell
- add resource constraints to `quickstart/docker/canton-console/compose.yaml` for canton console
- renamed compose service `postgres` to `keycloak-postgres` to make the service name match it's purpose
- added Make target `compose-config` to enable rendering docker compose configuration for inspection

## Additional Changes 
- add `.DS_Store` to `.gitignore` to stop files left behind by Finder on MacOS from being considered by git

## Notes

- All JVM based services have had `_JAVA_OPTIONS` environment variable populated with `-XX:-UseCompressedOops`, `-Xms` and `-Xmx` (or `-XX:+UseContainerSupport` in select circumstances) arguments to assist the JVM in being aware of running in container and ensuring heap sizes fit the `mem_limit` applied in the compose templates.

### Outcome

The memory footprint of the all the running services has been reduced:

```shell
❯ docker stats --no-stream --format '{{.MemUsage}}' | awk '{print $1}' | sed 's/GiB/ * 1024/;s/MiB//;s/KiB/ \/ 1024/' | bc -l | awk '{s+=$1} END {print s}'
15547.8
```

Below is a list of all services with memory stats when the resource constraints are applied:

```shell
❯ docker stats -a --no-stream --format "table {{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}"
NAME                                   MEM USAGE / LIMIT     MEM %
backend-service                        698.3MiB / 1GiB       68.19%
backend-service-auto-config            632KiB / 32MiB        1.93%
cadvisor                               111MiB / 256MiB       43.37%
global-synchronizer                    1002MiB / 1GiB        97.83%
grafana                                86.88MiB / 256MiB     33.94%
keycloak                               737.1MiB / 1GiB       71.98%
keycloak-postgres                      24.3MiB / 256MiB      9.49%
loki                                   169MiB / 512MiB       33.01%
nginx-app-provider                     3.438MiB / 32MiB      10.74%
nginx-app-provider-metrics             4.977MiB / 32MiB      15.55%
nginx-app-user                         2.328MiB / 32MiB      7.28%
nginx-app-user-metrics                 6.445MiB / 32MiB      20.14%
nginx-keycloak                         2.238MiB / 32MiB      6.99%
nginx-sv                               2.184MiB / 32MiB      6.82%
nginx-sv-metrics                       21.92MiB / 32MiB      68.51%
otel-collector                         180MiB / 1GiB         17.58%
participant-app-provider               1.846GiB / 2GiB       92.29%
participant-app-user                   1.565GiB / 2GiB       78.27%
participant-sv                         1.688GiB / 2GiB       84.42%
postgres-splice                        644KiB / 512MiB       0.12%
postgres-splice-app-provider           288.2MiB / 512MiB     56.30%
postgres-splice-app-provider-metrics   3.051MiB / 32MiB      9.53%
postgres-splice-app-user               233MiB / 512MiB       45.51%
postgres-splice-app-user-metrics       5.035MiB / 32MiB      15.73%
postgres-splice-sv                     354.5MiB / 512MiB     69.25%
postgres-splice-sv-metrics             14.14MiB / 32MiB      44.18%
pqs                                    854.6MiB / 1GiB       83.45%
prometheus                             115.6MiB / 256MiB     45.15%
scan                                   878.6MiB / 1GiB       85.80%
scan-web-ui                            6.133MiB / 256MiB     2.40%
sv-app                                 973.8MiB / 1GiB       95.10%
sv-web-ui                              6.242MiB / 512MiB     1.22%
tempo                                  290MiB / 1GiB         28.32%
validator-app-provider                 1010MiB / 1GiB        98.64%
validator-app-provider-auto-config     932KiB / 32MiB        2.84%
validator-app-user                     1021MiB / 1GiB        99.70%
validator-app-user-auto-config         620KiB / 32MiB        1.89%
validator-sv                           1.06GiB / 2GiB        52.99%
wallet-web-ui-app-provider             6.34MiB / 256MiB      2.48%
wallet-web-ui-app-user                 6.82MiB / 256MiB      2.66%
wallet-web-ui-sv                       6.07MiB / 256MiB      2.37%
```