### PR TITLE
FIX: move disabling gradle daemon from environment variable to gradle.properties

### DIFF
--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -19,9 +19,6 @@ endif
 # Set default goal to 'help' if no target is specified
 .DEFAULT_GOAL := help
 
-# Disable gradle daemon:
-export GRADLE_OPTS = -Dorg.gradle.daemon=false
-
 # Determine the operating system
 KERNEL_NAME := $(shell uname -s)
 DOCKER_COMPOSE_ENVFILE := --env-file .env.local --env-file .env --env-file env/ports.env

--- a/quickstart/gradle.properties
+++ b/quickstart/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false


### PR DESCRIPTION
Move where we declare disabling gradle daemon in the project due a race condition that occurs when building the project.

## Changes
- add gradle.properties with org.gradle.daemon=false to disable gradle daemon for the project
- remove exporting GRADLE_OPTS in Makefile as the option is now set in the properties file above