### PR TITLE
allow to merge custom compose file with additional settings and overrides

### DIFF
--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -22,7 +22,7 @@ endif
 # Determine the operating system
 KERNEL_NAME := $(shell uname -s)
 DOCKER_COMPOSE_ENVFILE := --env-file .env.local --env-file .env --env-file env/ports.env
-DOCKER_COMPOSE_FILES := -f compose.yaml
+DOCKER_COMPOSE_FILES ?= -f compose.yaml
 
 # Default to adding resource constraints for Quickstart compose stack.
 RESOURCE_CONSTRAINTS_ENABLED ?= true


### PR DESCRIPTION
As discussed with @peterkvokacka-da, to make pqs config overridable outside cn-quickstart, the change is made in Make file to take extra compose files by overriding `DOCKER_COMPOSE_FILES`
