### PR TITLE
Fix ports config in canton consoles

### DIFF
--- a/quickstart/docker/canton-console/compose.yaml
+++ b/quickstart/docker/canton-console/compose.yaml
@@ -16,8 +16,8 @@ services:
       - ../../docker/canton-console/entrypoint.sh:/app/entrypoint.sh
     environment:
       - _JAVA_OPTIONS=-XX:+UseContainerSupport -XX:-UseCompressedOops
-      - PARTICIPANT_LEDGER_API_PORT=${PARTICIPANT_LEDGER_API_PORT}
-      - PARTICIPANT_ADMIN_API_PORT=${PARTICIPANT_ADMIN_API_PORT}
+      - PARTICIPANT_LEDGER_API_PORT=3${PARTICIPANT_LEDGER_API_PORT}
+      - PARTICIPANT_ADMIN_API_PORT=3${PARTICIPANT_ADMIN_API_PORT}
       - LEDGER_API_ADDRESS=canton
       - CLIENT_ID=app-provider-validator
       - SECRET=${AUTH_APP_PROVIDER_VALIDATOR_CLIENT_SECRET}
@@ -36,8 +36,8 @@ services:
       - ../../docker/canton-console/entrypoint.sh:/app/entrypoint.sh
     environment:
       - _JAVA_OPTIONS=-XX:+UseContainerSupport -XX:-UseCompressedOops
-      - PARTICIPANT_LEDGER_API_PORT=${PARTICIPANT_LEDGER_API_PORT}
-      - PARTICIPANT_ADMIN_API_PORT=${PARTICIPANT_ADMIN_API_PORT}
+      - PARTICIPANT_LEDGER_API_PORT=2${PARTICIPANT_LEDGER_API_PORT}
+      - PARTICIPANT_ADMIN_API_PORT=2${PARTICIPANT_ADMIN_API_PORT}
       - LEDGER_API_ADDRESS=canton
       - CLIENT_ID=app-user-validator
       - SECRET=${AUTH_APP_USER_VALIDATOR_CLIENT_SECRET}


### PR DESCRIPTION
Fix #112 

```
@ participant.health.status
res0: NodeStatus[ParticipantStatus] = Participant id: PAR::participant::1220a500e31b146873dc4fee8d49efe88d08a10ec962a0e50ac68cb28196635733e6
Uptime: 1h 20m 5.259057s
Ports: 
        ledger: 35001
        admin: 35002
Connected synchronizers: 
        global-domain::1220bc00b82e...
Unhealthy synchronizers: None
Active: true
Components: 
        db-storage : Ok()
        connected-synchronizer : Ok()
        sync-ephemeral-state : Ok()
        sequencer-client : Ok()
        acs-commitment-processor : Ok()
Version: 3.3.0-SNAPSHOT
Supported protocol version(s): 33, dev
```