### PR TITLE
Point SDK to release, add daml test targets

### DIFF
--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -92,6 +92,13 @@ build-backend: ## Build the backend service
 build-daml: ## Build the Daml model
 	./gradlew :daml:build distTar
 
+.PHONY: test
+test: test-daml ## Run unit tests
+
+.PHONY: test-daml
+test-daml: ## Run daml tests
+	./gradlew :daml:testDaml
+
 .PHONY: build-docker-images
 build-docker-images:
 	$(call docker-compose, ${DOCKER_COMPOSE_OBSERVABILITY_FILES} $(RESOURCE_CONSTRAINT_CONFIG) build)

--- a/quickstart/daml/build.gradle.kts
+++ b/quickstart/daml/build.gradle.kts
@@ -21,6 +21,10 @@ tasks.register<Exec>("compileDaml") {
     commandLine("daml", "damlc", "build", "--all")
 }
 
+tasks.register<Exec>("testDaml") {
+    commandLine("daml", "test", "--project-root", "licensing-tests")
+}
+
 tasks.register<com.digitalasset.transcode.codegen.java.gradle.JavaCodegenTask>("codeGen") {
     dar.from("$projectDir/licensing/.daml/dist/quickstart-licensing-0.0.1.dar")
     destination = file("$rootDir/backend/build/generated-daml-bindings")

--- a/quickstart/daml/external-test-sources/splice-amulet-test/daml.yaml
+++ b/quickstart/daml/external-test-sources/splice-amulet-test/daml.yaml
@@ -3,7 +3,7 @@
 # classes. You should either use `daml build` or `sbt ~compile`, but NOT both
 # at the same time (see #179 for more context).
 
-sdk-version: 3.3.0-snapshot.20250409.13730.0.v6972616a
+sdk-version: 3.3.0-snapshot.20250410.0
 name: splice-amulet-test
 source: daml
 version: 0.1.9

--- a/quickstart/daml/external-test-sources/splice-token-standard-test/daml.yaml
+++ b/quickstart/daml/external-test-sources/splice-token-standard-test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.3.0-snapshot.20250409.13730.0.v6972616a
+sdk-version: 3.3.0-snapshot.20250410.0
 name: splice-token-standard-test
 description: |
   Test infrastructure for the token standard.

--- a/quickstart/daml/external-test-sources/splice-wallet-test/daml.yaml
+++ b/quickstart/daml/external-test-sources/splice-wallet-test/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 3.3.0-snapshot.20250409.13730.0.v6972616a
+sdk-version: 3.3.0-snapshot.20250410.0
 name: splice-wallet-test
 source: daml
 version: 0.1.9

--- a/quickstart/daml/licensing-tests/daml.yaml
+++ b/quickstart/daml/licensing-tests/daml.yaml
@@ -1,7 +1,7 @@
 # for config file options, refer to
 # https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
 
-sdk-version: 3.3.0-snapshot.20250409.13730.0.v6972616a
+sdk-version: 3.3.0-snapshot.20250410.0
 name: quickstart-licensing-tests
 source: daml
 version: 0.0.1

--- a/quickstart/daml/licensing/daml.yaml
+++ b/quickstart/daml/licensing/daml.yaml
@@ -1,7 +1,7 @@
 # for config file options, refer to
 # https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
 
-sdk-version: 3.3.0-snapshot.20250409.13730.0.v6972616a
+sdk-version: 3.3.0-snapshot.20250410.0
 name: quickstart-licensing
 source: daml
 version: 0.0.1


### PR DESCRIPTION
- Point daml SDK version to https://github.com/digital-asset/daml/releases/tag/v3.3.0-snapshot.20250410.0 which is based on `SDK 3.3.0-snapshot.20250409.13730.0.v6972616a`.
- Add tasks and targets to run daml tests