### PR TITLE
Fix VSCode import of Gradle build and Java projects

### DIFF
--- a/quickstart/backend/build.gradle.kts
+++ b/quickstart/backend/build.gradle.kts
@@ -115,7 +115,7 @@ sourceSets {
     main {
         java {
             srcDirs(
-                "$projectDir/build/generated-spring/src/main",
+                "$projectDir/build/generated-spring/src/main/java",
                 "$projectDir/build/generated-client/src/main/java",
                 "$projectDir/build/generated-daml-bindings" // TODO: remove this line once daml plugin is used
             )

--- a/quickstart/buildSrc/src/main/kotlin/VersionFiles.kt
+++ b/quickstart/buildSrc/src/main/kotlin/VersionFiles.kt
@@ -6,7 +6,7 @@ import java.io.File
 object VersionFiles {
     val dotenv: Map<String, String>
         get() {
-            val rootProjectDir = File(System.getProperty("user.dir"))
+            val rootProjectDir = File(System.getProperty("gradle.root.dir"))
             val dotEnvFile = File(rootProjectDir, ".env")
 
             if (!dotEnvFile.exists()) {
@@ -19,7 +19,7 @@ object VersionFiles {
 
     val damlYamlSdk: String
         get() {
-            val rootProjectDir = File(System.getProperty("user.dir"))
+            val rootProjectDir = File(System.getProperty("gradle.root.dir"))
             val damlYamlFile = File(rootProjectDir, "daml/licensing/daml.yaml")
 
             if (!damlYamlFile.exists()) {

--- a/quickstart/settings.gradle.kts
+++ b/quickstart/settings.gradle.kts
@@ -8,6 +8,8 @@
  * For more detailed information on multi-project builds, please refer to https://docs.gradle.org/8.8/userguide/multi_project_builds.html in the Gradle documentation.
  */
 
+System.setProperty("gradle.root.dir", rootDir.toString())
+
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"


### PR DESCRIPTION
The first commit fixes loading the Gradle build in the Gradle for Java extension.

The error was:
```
* Where:
Build file '/Users/adrienpiquerez/github/digital-asset/cn-quickstart2/quickstart/backend/build.gradle.kts' line: 24

* What went wrong:
.env file not found in project root directory (expected at /Users/adrienpiquerez/.vscode/extensions/vscjava.vscode-gradle-3.16.4/lib/.env)
```
That's because the Gradle extension starts Gradle in its own folder, and not in the project root folder. As such it could not find the `.env` file at the project root dir. To fix this we can set a `gradle.root.dir` property and use it instead of `user.dir`.

The second commit fixes the false compilation errors in the Java workspace by declaring the correct source directory for the generated spring Java files.

After this PR I can fully import the Java projects in VSCode, and use code completion and code navigation.