### PR TITLE
Fix console authentication

### DIFF
--- a/quickstart/Makefile
+++ b/quickstart/Makefile
@@ -186,7 +186,7 @@ integration-test/node_modules:
 # Console
 .PHONY: console-app-provider
 console-app-provider: ## Start the Canton console
-	docker compose -f docker/canton-console/compose.yaml $(DOCKER_COMPOSE_ENVFILE) run --rm canton-console-app-provider
+	docker compose -f docker/canton-console/compose.yaml $(DOCKER_COMPOSE_ENVFILE) --env-file env/app-provider.env run --rm canton-console-app-provider
 
 .PHONY: clean-console-app-provider
 clean-console-app-provider: ## Stop and remove the Canton console container
@@ -194,7 +194,7 @@ clean-console-app-provider: ## Stop and remove the Canton console container
 
 .PHONY: console-app-user
 console-app-user: ## Start the Canton console
-	docker compose -f docker/canton-console/compose.yaml $(DOCKER_COMPOSE_ENVFILE) run --rm canton-console-app-user
+	docker compose -f docker/canton-console/compose.yaml $(DOCKER_COMPOSE_ENVFILE) --env-file env/app-user.env run --rm canton-console-app-user
 
 .PHONY: clean-console-app-user
 clean-console-app-user: ## Stop and remove the Canton console container


### PR DESCRIPTION
If you run `make console-app-provider` or `make console-app-user` you'll see that the authentication variables are missing:

```shell
$ make console-app-provider
docker compose -f docker/canton-console/compose.yaml --env-file .env --env-file .env.local --env-file env/ports.env run --rm canton-console-app-provider
WARN[0000] The "AUTH_APP_PROVIDER_VALIDATOR_CLIENT_SECRET" variable is not set. Defaulting to a blank string. 
WARN[0000] The "AUTH_APP_PROVIDER_TOKEN_URL" variable is not set. Defaulting to a blank string. 
WARN[0000] The "AUTH_APP_USER_VALIDATOR_CLIENT_SECRET" variable is not set. Defaulting to a blank string. 
WARN[0000] The "AUTH_APP_USER_TOKEN_URL" variable is not set. Defaulting to a blank string.
```

This PR fixes the issue by loading the `env/app-provider.env` and `env/app-user.env` when needed.