### PR TITLE
Add WIP markers and orphan conflicting docs pages

### DIFF
--- a/sdk/docs/sharable/sdk/quickstart/configure/dev-journey-in-cnqs-lifecycle.rst
+++ b/sdk/docs/sharable/sdk/quickstart/configure/dev-journey-in-cnqs-lifecycle.rst
@@ -1,5 +1,7 @@
-Development journey in the CN QS lifecycle 
+Development journey in the CN QS lifecycle
 ===========================================
+
+.. wip::
 
 **Contents**
 
@@ -387,7 +389,7 @@ CANTON_PARAMETERS:
 Sample application
 ------------------
 
-The CN QS includes a complete reference application that demonstrates Canton Network application patterns. 
+The CN QS includes a complete reference application that demonstrates Canton Network application patterns.
 While you'll likely replace this component entirely, understanding its architecture provides valuable insights for your own application design.
 
 Application components
@@ -421,5 +423,5 @@ Application components
 
 **Technical implementation**
 
-The API Design is defined in quickstart/common/openapi.yaml. 
+The API Design is defined in quickstart/common/openapi.yaml.
 It contains the RESTful API definitions, establishes the JSON schema for request/response objects, provides error handling conventions, and creates authentication patterns.

--- a/sdk/docs/sharable/sdk/quickstart/configure/development-lifecycle.rst
+++ b/sdk/docs/sharable/sdk/quickstart/configure/development-lifecycle.rst
@@ -1,6 +1,8 @@
 Development lifecycle
 =====================
 
+.. wip::
+
 **Contents**
 
 `Development lifecycle <#development-lifecycle>`__
@@ -20,11 +22,11 @@ Development lifecycle
    `Separation phase <#separation-phase>`__
 
    `Ongoing updates <#ongoing-updates>`__
-   
+
 We’ve observed five distinct phases of the CN QS development journey.
 Each phase presents unique strategies for interacting with the CN QS.
 
-Learning phase 
+Learning phase
 ---------------
 
 (½ - 2 weeks)
@@ -246,11 +248,11 @@ historical development record.
 Ongoing updates
 ---------------
 
-By now, your application is likely to outgrow the capabilities of the CN QS. 
-However, you may want the ability to update the development tooling or LocalNet support. 
+By now, your application is likely to outgrow the capabilities of the CN QS.
+However, you may want the ability to update the development tooling or LocalNet support.
 The CN QS continuously adds more tooling features and updates existing tool versions.
 
-This process includes periodically checking into CN QS, reviewing the ChangeLog to see what is new, and then selecting components you’d like to include in your application. 
+This process includes periodically checking into CN QS, reviewing the ChangeLog to see what is new, and then selecting components you’d like to include in your application.
 You’ll find the CN QS to be a source for improvements, rather than a direct dependency.
 
 We recommend establishing a regular schedule (monthly or quarterly) to review CN QS updates.

--- a/sdk/docs/sharable/sdk/quickstart/configure/project-structure-overview.rst
+++ b/sdk/docs/sharable/sdk/quickstart/configure/project-structure-overview.rst
@@ -2,6 +2,8 @@
 Canton Network quickstart project structure guide
 =================================================
 
+.. wip::
+
 **Contents**
 
 `Project structure overview <#project-structure-overview>`__
@@ -396,7 +398,7 @@ four-digit port number associated with the relevant service.
      - Application Provider
    * - `4${PORT}`
      - Super Validator
-    
+
 `LocalNet` port suffixes are as follows:
 
 .. list-table:: LocalNet Port Suffixes
@@ -625,7 +627,7 @@ Create command to Org1’s participant node via its HTTP Ledger JSON API
             ]
         }'
     }
-   
+
    create_app_install_request "$LEDGER_API_ADMIN_USER_TOKEN_APP_USER" \
    $DSO_PARTY $APP_USER_PARTY $APP_PROVIDER_PARTY participant-app-user
 
@@ -688,7 +690,7 @@ ledger.
     |                       ║ user: Org1: :12203a9a79d8f72b8cce37813713af7a51296def8...   │
     |                       ║ provider: AppProvider: :122030b08cfebb8c87c16793cba3783...  │
     ╚═══════════════════════╩═════════════════════════════════════════════════════════════╝
-    postgres-splice-app-provider:5432/scribe 3f → 42> 
+    postgres-splice-app-provider:5432/scribe 3f → 42>
 
 Exercising the `AppInstallRequest_Accept` choice completes the onboarding.
 The Frontend UI provides a way to do this.
@@ -860,7 +862,7 @@ Typescript [34]_. It accesses the Backend web services using the
 generator-less Axios client to handle the lowest level transport,
 configured in `src/api.ts`:
 
-.. code-block:: 
+.. code-block::
 
    import OpenAPIClientAxios from 'openapi-client-axios';
    import openApi from '../../common/openapi.yaml';
@@ -871,7 +873,7 @@ configured in `src/api.ts`:
    });
 
    api.init();
-   
+
    export default api;
 
 Authentication is handled using OAuth2 against a mock OAuth server [35]_
@@ -901,7 +903,7 @@ The basic format of a make build target is:
    <target>: <dependency list (space separated)>
          shell commands, make macros, and gnu-make function invocations
 
-For instance to build the front-end you can run `npm install && npm run build` 
+For instance to build the front-end you can run `npm install && npm run build`
 from the `frontend/` directory; or, make build-frontend from the
 quickstart/ directory via the following target in quickstart/Makefile:
 
@@ -955,7 +957,7 @@ browser interaction targets (try `make open-app-ui` once the application
 is started for an example). The file also includes:
 
 .. code-block:: text
-   
+
    # Function to run docker-compose with default files and environment
    define docker-compose
    docker compose $(DOCKER_COMPOSE_FILES) $(DOCKER_COMPOSE_ENVFILE) \

--- a/sdk/docs/sharable/sdk/quickstart/observe/observability-troubleshooting-overview.rst
+++ b/sdk/docs/sharable/sdk/quickstart/observe/observability-troubleshooting-overview.rst
@@ -2,10 +2,12 @@
 Canton Network quickstart observability & troubleshooting overview
 ==================================================================
 
+.. wip::
+
 .. Note:: The screenshots in this guide are currently taken from
    multiple sessions over multiple days and therefore are inconsistent
-   with each other (and in some places the text). 
-   This will be rectified once some of the updates to Quickstart 
+   with each other (and in some places the text).
+   This will be rectified once some of the updates to Quickstart
    currently in flight are committed.
 
 **Contents**
@@ -59,8 +61,8 @@ The LocalNet configuration
 The Quickstart runtime configuration is defined in `.env.local`, which
 allows each developer to switch between running a `LocalNet` or `DevNet`
 application deployment; and, whether or not to bring up a local
-deployment of the Observability Stack. This file can be created using `$ make setup`, 
-which wraps the command `$ ./gradlew configureProfiles --no-daemon --console=plain --quiet`, 
+deployment of the Observability Stack. This file can be created using `$ make setup`,
+which wraps the command `$ ./gradlew configureProfiles --no-daemon --console=plain --quiet`,
 or can be edited manually to set environment variables `LOCALNET_ENABLED` and `OBSERVABILITY_ENABLED` to `true`
 or `false` as desired.
 
@@ -77,7 +79,7 @@ Immediately useful commands you probably already know:
    follow the logs with the `-f` option.
 
    -  If the system is not working well to the extent you do not trust
-      the observability stack (discussed later), `docker logs backend-service` 
+      the observability stack (discussed later), `docker logs backend-service`
       is a good place to start looking for errors that
       might provide an insight into what has gone wrong.
 
@@ -127,7 +129,7 @@ application provider’s PQS instance. This is easiest to access via the
 toplevel project scripts accessed via `make` from `quickstart/`. To see this
 in action, build and start the quickstart app then:
 
-Run `$ make create-app-install-request` to use `curl` to submit the 
+Run `$ make create-app-install-request` to use `curl` to submit the
 `create AppInstallRequest ...` command to the ledger [1]_ to initiate user
 onboarding [2]_. Then you can use the following Daml Shell commands:
 
@@ -197,7 +199,7 @@ backend-service you will see the lines:
        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
     ports:
-   
+
       - "${BACKEND_PORT}:8080"
       - "5055:5005"
 
@@ -475,7 +477,7 @@ identifiers.
      - `Description`
      - `ID`
    * - `Command Id`
-     -  
+     -
      - `79062314-1354-439b-b5c8-b889bec1024f`
    * - `Contract Id`
      - `AppInstall`
@@ -485,9 +487,9 @@ identifiers.
      - `79062314-1354-439b-b5c8-b889bec1024f`
 
 As we have already seen, contract ids can be used in Daml Shell to
-inspect the contracts directly. 
-In addition, due to the way the OpenAPI interface for the Backend has been designed, 
-the Command Id is visible as a query parameter to the POST. 
+inspect the contracts directly.
+In addition, due to the way the OpenAPI interface for the Backend has been designed,
+the Command Id is visible as a query parameter to the POST.
 We can use this to query the consolidated logs in Grafana:
 
 .. image:: images/06-grafana-consolidated-logs.png

--- a/sdk/docs/sharable/sdk/quickstart/operate/explore-the-demo.rst
+++ b/sdk/docs/sharable/sdk/quickstart/operate/explore-the-demo.rst
@@ -1,5 +1,5 @@
 ==========================================
-Explore the Canton Network quickstart demo 
+Explore the Canton Network quickstart demo
 ==========================================
 
 **Contents**
@@ -31,8 +31,9 @@ Explore the Canton Network quickstart demo
 Exploring the demo
 ==================
 
-The CN QS and its guides are a work-in-progress (WIP). 
-As a result, the CN QS guides may not be a little out of step with the application. 
+.. wip::
+
+As a result, the CN QS guides may not be a little out of step with the application.
 If you find errors or other inconsistencies, please contact your representative at Digital Asset.
 
 This section works through a complete business operation within the CN QS.
@@ -47,14 +48,14 @@ Access to the `CN-Quickstart Github repository <https://github.com/digital-asset
 is needed to successfully pull the Digital Asset artifacts from JFrog Artifactory.
 
 Access to the *Daml-VPN* connection or `a SV Node <https://docs.dev.sync.global/validator_operator/validator_onboarding.html>`__
-that is whitelisted on the CN is required to connect to `DevNet`. 
-The GSF publishes a `list of SV nodes <https://sync.global/sv-network/>`__ who have the ability to sponsor a Validator node. 
+that is whitelisted on the CN is required to connect to `DevNet`.
+The GSF publishes a `list of SV nodes <https://sync.global/sv-network/>`__ who have the ability to sponsor a Validator node.
 To access `DevNet`, contact your sponsoring SV agent for VPN connection information.
 
 If you need support accessing the SV or VPN email support@digitalasset.com.
 
-The CN QS is a Dockerized application and requires `Docker Desktop <https://www.docker.com/products/docker-desktop/>`__. 
-It is recommended to allocate 8 GB of memory and 3 GB of Swap memory to properly run the required Docker containers. 
+The CN QS is a Dockerized application and requires `Docker Desktop <https://www.docker.com/products/docker-desktop/>`__.
+It is recommended to allocate 8 GB of memory and 3 GB of Swap memory to properly run the required Docker containers.
 If you witness unhealthy containers, please consider allocating additional resources, if possible.
 
 `DevNet` is less intensive because the SVs and other `LocalNet` containers are hosted outside of your local machine.
@@ -140,8 +141,8 @@ In the `AppProvider`, “Pat the provider’s,” account, navigate to the **Lic
    :alt: Licenses view
    :width: 60%
 
-An “Actions for License” modal opens with an option to renew or expire the license. 
-Per the Daml contract, licenses are created in an expired state. 
+An “Actions for License” modal opens with an option to renew or expire the license.
+Per the Daml contract, licenses are created in an expired state.
 To activate the license, it must be renewed.
 
 .. image:: images/10-license-modal.png
@@ -166,8 +167,8 @@ The license is now available for a 30-day extension for a flat fee of $100 CC.
 
 Pat the provider has done as much as they are able until Alice pays the renewal fee.
 
-   💡For the next step we recommend opening a separate browser in incognito mode. 
-   Each user should be logged into separate browsers for most consistent results. 
+   💡For the next step we recommend opening a separate browser in incognito mode.
+   Each user should be logged into separate browsers for most consistent results.
    For example, if you logged into `AppProvider` using Chrome, you would use Firefox when logging into `AppUser`.
 
 Navigate to http://localhost:3000/login using a separate browser in incognito or private mode.
@@ -234,12 +235,12 @@ Congratulations. You’ve successfully created and activated a license with a pa
 Canton Console
 --------------
 
-The Canton Console connects to the running application ledger. 
-The console allows a developer to bypass the UI to interact with the CN in a more direct manner. 
+The Canton Console connects to the running application ledger.
+The console allows a developer to bypass the UI to interact with the CN in a more direct manner.
 For example, in Canton Console you can connect to the Participant to see the location of the Participant and their synchronizer domain.
 
-The app provider and the app user each have their own console. 
-To activate the app provider’s Canton Console in a terminal from the `quickstart/` directory. 
+The app provider and the app user each have their own console.
+To activate the app provider’s Canton Console in a terminal from the `quickstart/` directory.
 Run:
 
 `make console-app-provider`
@@ -266,8 +267,8 @@ Shows the Participant’s synchronizer.
 
 `participant.health.ping(participant)`
 
-Runs a health ping. 
-The ping makes a round trip through the CN blockchain. 
+Runs a health ping.
+The ping makes a round trip through the CN blockchain.
 Pinging yourself validates communication throughout the entire network.
 
 .. image:: images/27-console-ping.png
@@ -276,7 +277,7 @@ Pinging yourself validates communication throughout the entire network.
 Daml Shell
 ----------
 
-The Daml Shell connects to the running PQS database of the application provider’s Participant. 
+The Daml Shell connects to the running PQS database of the application provider’s Participant.
 In the Shell, the assets and their details are available in real time.
 
 Run the shell from quickstart/ in the terminal with:
@@ -369,19 +370,19 @@ Configuring non-default DevNet sponsors
 
 In `DevNet` mode, you can configure a non-default `SPONSOR_SV_ADDRESS`, `SCAN_ADDRESS` and `ONBOARDING_SECRET_URL` or `ONBOARDING_SECRET` in the `quickstart/.env` file.
 
-   💡 Connecting to `DevNet` requires a connection to an `approved SV <https://sync.global/docs/>`__. 
+   💡 Connecting to `DevNet` requires a connection to an `approved SV <https://sync.global/docs/>`__.
    If your organization provides access to the DAML-VPN, then connect to it to access the Digital Asset-sponsored SV.
 
-   Your organization may sponsor another `CN-approved SV <https://sync.global/sv-network/>`__. 
+   Your organization may sponsor another `CN-approved SV <https://sync.global/sv-network/>`__.
    If this is the case, speak with your administrator for privileged access.
 
    Review the `DevNet` Global Synchronizer documentation to learn more about the `SV onboarding process <https://docs.dev.sync.global/validator_operator/validator_onboarding.html#onboarding-process-overview>`__.
 
-   ⏱️ If you run into errors when making `DevNet` operations, double check that the `DevNet` VPN is active. 
+   ⏱️ If you run into errors when making `DevNet` operations, double check that the `DevNet` VPN is active.
    `DevNet` VPNs may timeout, especially if left unattended for extended periods of time.
 
-In an incognito browser navigate to `localhost:3000/login`. 
-Login as the Org1 user and create and archive assets, as before. 
+In an incognito browser navigate to `localhost:3000/login`.
+Login as the Org1 user and create and archive assets, as before.
 Logout and do the same as the `AppProvider`.
 
 Canton Coin Scan
@@ -423,7 +424,7 @@ The default view shows a running stream of all services.
    :alt: service stream
    :width: 55%
 
-Change the services filter from “All” to “participant” to view participant logs. 
+Change the services filter from “All” to “participant” to view participant logs.
 Select any log entry to view its details.
 
 .. image:: images/40-log-entry-details.png
@@ -433,7 +434,7 @@ Select any log entry to view its details.
 SV UIs
 ------
 
-Navigate to http://sv.localhost:4000/ for the SV Web UI. 
+Navigate to http://sv.localhost:4000/ for the SV Web UI.
 The SV view displays data directly from the validator in a GUI that is straightforward to navigate.
 
 Login as ‘administrator’.

--- a/sdk/docs/sharable/sdk/quickstart/operate/index.rst
+++ b/sdk/docs/sharable/sdk/quickstart/operate/index.rst
@@ -1,3 +1,7 @@
+:orphan:
+
+.. todo: https://github.com/digital-asset/cn-quickstart/issues/144 -- determine whether and what to keep
+
 .. _quickstart_operate:
 
 Operate

--- a/sdk/docs/sharable/sdk/quickstart/operate/introduction-to-splice-in-cn.rst
+++ b/sdk/docs/sharable/sdk/quickstart/operate/introduction-to-splice-in-cn.rst
@@ -1,3 +1,7 @@
+:orphan:
+
+.. todo: https://github.com/digital-asset/cn-quickstart/issues/144 -- determine whether and what to keep
+
 ============================================
 Introduction to Splice in the Canton Network
 ============================================

--- a/sdk/docs/sharable/sdk/quickstart/secure/keycloak-in-cnqs.rst
+++ b/sdk/docs/sharable/sdk/quickstart/secure/keycloak-in-cnqs.rst
@@ -1,6 +1,8 @@
 Keycloak in the CN QS
 =====================
 
+.. wip::
+
 **Contents**
 
 `Keycloak in the CN QS <#keycloak-in-the-cn-qs>`__
@@ -25,18 +27,18 @@ Keycloak in the CN QS
 
    `Troubleshooting <#troubleshooting>`__
 
-Keycloak is an open-source Identity and Access Management (IAM) solution that provides authentication, authorization, and user management for modern applications and services. 
+Keycloak is an open-source Identity and Access Management (IAM) solution that provides authentication, authorization, and user management for modern applications and services.
 It acts as a centralized authentication server that handles user logins, session management, and security token issuance.
 
-The CN QS uses Keycloak to provide secure authentication across its distributed architecture. 
+The CN QS uses Keycloak to provide secure authentication across its distributed architecture.
 Keycloak maintains separation between authentication concerns and business logic.
 
 Realm structure
 ---------------
 
-The CN QS defines two Keycloak realms. 
-The AppProvider realm manages authentication for services and users on the provider side of the application. 
-The AppUser realm handles authentication for the consumer side. 
+The CN QS defines two Keycloak realms.
+The AppProvider realm manages authentication for services and users on the provider side of the application.
+The AppUser realm handles authentication for the consumer side.
 When components like validators or participant nodes receive requests, they validate the authentication tokens against the appropriate realm.
 
 Keycloak configuration
@@ -252,7 +254,7 @@ Find **keycloak** near **grafana** and **loki** in the list.
 2. Check keycloak credentials in `.env` file
 
 ::
-  
+
    AUTH_APP_USER_ISSUER_URL_BACKEND=http://nginx-keycloak:8082/realms/AppUser
    # for backend
 

--- a/sdk/docs/sharable/sdk/quickstart/troubleshoot/cnqs-faq.rst
+++ b/sdk/docs/sharable/sdk/quickstart/troubleshoot/cnqs-faq.rst
@@ -2,6 +2,8 @@
 Canton Network quickstart FAQ
 =============================
 
+.. wip::
+
 **Contents**
 
 `CN QS Frequently Asked Questions <#cn-qs-frequently-asked-questions>`__
@@ -33,20 +35,20 @@ Canton Network quickstart FAQ
 
 **Have the best technologies been selected for the CN QS?**
 
-The Quickstart (QS) is designed to help teams become familiar with Canton Network (CN) application development by providing scaffolding to kickstart development. 
-The QS application is intended to be incrementally extended by you to meet your specific business needs. 
-Once you are familiar with the QS, please review the technology choices and the application design to determine what changes are needed - technology and design decisions are ultimately up to you. 
+The Quickstart (QS) is designed to help teams become familiar with Canton Network (CN) application development by providing scaffolding to kickstart development.
+The QS application is intended to be incrementally extended by you to meet your specific business needs.
+Once you are familiar with the QS, please review the technology choices and the application design to determine what changes are needed - technology and design decisions are ultimately up to you.
 Please be aware that the Canton Network Quickstart (CN QS) is a rapidly evolving work in progress.
 
 **What are the minimum system requirements to run CN QS LocalNet?**
 
-The CN QS requires Docker Desktop with at least 8 GB of memory allocated to run `LocalNet` properly. 
+The CN QS requires Docker Desktop with at least 8 GB of memory allocated to run `LocalNet` properly.
 If your machine has less memory, consider declining Observability when prompted during setup.
 
 **Which browsers are supported for running CN QS?**
 
-Chromium browsers such as Chrome, Edge, and Firefox are recommended. 
-Safari has known issues with local URLs and should be avoided. 
+Chromium browsers such as Chrome, Edge, and Firefox are recommended.
+Safari has known issues with local URLs and should be avoided.
 You may also use the same browser with one user in incognito mode and the other in standard mode.
 
 **How should I test** Participant **and** User **interactions on**
@@ -70,12 +72,12 @@ For more information see the Installation Guide.
 
 **Why is Nix-shell unable to download my SSL certificate?**
 
-The Nix prerequisite may introduce hurdles to installation if your enterprise runs behind a corporate proxy. 
+The Nix prerequisite may introduce hurdles to installation if your enterprise runs behind a corporate proxy.
 If nix-shell is not found, then verify that `/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt`
 contains your corporate CA.
 
-CN, PQS, Daml Shell and other CN QS related services run on a user-supplied JVM. 
-CN QS assumes that you have access to JVM v17+ with access to the internet. 
+CN, PQS, Daml Shell and other CN QS related services run on a user-supplied JVM.
+CN QS assumes that you have access to JVM v17+ with access to the internet.
 If your organization operates behind a web proxy then JVM may not have automatic knowledge of the corporate certificate.
 In these instances, JVM must be instructed to trust the certificate.
 
@@ -95,7 +97,7 @@ If the log returns an error message such as:
    error: unable to download 'https://nixos.org/channels/nixpkgs-unstable':
    SSL peer certificate or SSH remote key was not OK (60)
 
-Then the required corporate CA does not exist. 
+Then the required corporate CA does not exist.
 Request your corporate CA from your organization’s tech administrator and merge the certificate into the Nix `certs ca-bundle.crt`.
 
 If you need additional support, the `Nix reference manual <https://nix.dev/manual/nix/2.24/command-ref/conf-file.html#conf-ssl-cert-file>`__
@@ -103,15 +105,15 @@ offers guidance regarding the order at which cert files are detected and used on
 
 Graham Christensen’s Determinate Systems blog offers a solution for Nix
 `corporate TLS certificates <https://determinate.systems/posts/zscaler-macos-and-nix-on-corporate-networks/>`__
-problems on MacOS. 
-The NixOS team forked this solution as an `experimental installer <https://github.com/NixOS/experimental-nix-installer>`__ 
+problems on MacOS.
+The NixOS team forked this solution as an `experimental installer <https://github.com/NixOS/experimental-nix-installer>`__
 that is stable on most operating systems.
 
 **Should I build with make or gradle?**
 
 The gradle daemon has been disabled to prevent parallel processing of transcodegen.
 
-Gradle tasks had been known to create order and concurrency issues which caused files to get cleaned too early. 
+Gradle tasks had been known to create order and concurrency issues which caused files to get cleaned too early.
 Always prefer to use the make commands.
 
 **How do I resolve a “build failed with an exception failure”?**
@@ -123,7 +125,7 @@ If `make install-daml-sdk` results in:
    Task :daml:unpackDamlSdk FAILED
    FAILURE: Build failed with an exception
 
-Then you may have a corrupted `daml-sdk snapshot`. 
+Then you may have a corrupted `daml-sdk snapshot`.
 In most cases, deleting the identified tarball snapshot will resolve the issue in subsequent installation attempts.
 
 This error may occur if `make install-daml-sdk` is interrupted.
@@ -231,7 +233,7 @@ Run `make setup` to create the `.env.local` file.
 
 **How do I access the Daml Shell for debugging?**
 
-Run `make shell` from the quickstart directory. 
+Run `make shell` from the quickstart directory.
 This provides access to useful commands like:
 
 -  `active` - shows summary of contracts
@@ -257,16 +259,16 @@ The CN QS provides several observability options:
 
 `LocalNet` runs everything locally including a Super Validator and Canton Coin wallet, making it more resource intensive but self-contained.
 
-`DevNet` connects to actual decentralized Global Synchronizer infrastructure operated by Super Validators. 
+`DevNet` connects to actual decentralized Global Synchronizer infrastructure operated by Super Validators.
 `DevNet` requires less local resources but needs whitelisted VPN access and connectivity.
 
 For more information see the Project Structure Guide.
 
 **What is ScratchNet?**
 
-`ScratchNet` is a persistent Canton Network environment that supports team collaboration while maintaining centralized control. 
-It fills the gap between a single-developer LocalNet (constrained by one laptop's resources) and a fully decentralized DevNet (maintained by Super Validators). 
-Development teams typically deploy `ScratchNet` on a shared server to enable longer-running instances with persistent data storage across development sessions. 
+`ScratchNet` is a persistent Canton Network environment that supports team collaboration while maintaining centralized control.
+It fills the gap between a single-developer LocalNet (constrained by one laptop's resources) and a fully decentralized DevNet (maintained by Super Validators).
+Development teams typically deploy `ScratchNet` on a shared server to enable longer-running instances with persistent data storage across development sessions.
 Learn more about `ScratchNet` in the Exploring the Demo Guide.
 
 **How can I find out the migration_id of DevNet?**
@@ -275,7 +277,7 @@ Go to https://sync.global/sv-network/ and look for the `migration_id` value.
 
 **Do I need VPN access to use CN QS?**
 
-VPN access is only required for `DevNet` connections. 
+VPN access is only required for `DevNet` connections.
 You need either:
 
 -  Access to the DAML-VPN
@@ -286,7 +288,7 @@ For more information see the Exploring the Demo Guide.
 
 **How do I log in with Keycloak?**
 
-The CN QS uses Keycloak for authentication. 
+The CN QS uses Keycloak for authentication.
 If you have issues with logging in with Keycloak credentials, you may begin troubleshooting by running make status to verify the Keycloak service is running.
 
 Keycloak should show healthy.
@@ -303,7 +305,7 @@ Keycloak credentials are set in `.env` with the following credentials:
    Username: AUTH_APP_USER_WALLET_ADMIN_USER_NAME (e.g. alice)
    Password: AUTH_APP_USER_WALLET_ADMIN_USER_PASSWORD (e.g. abc123)
 
-The Keycloak user must have the same ID as the ledger user’s ID. 
+The Keycloak user must have the same ID as the ledger user’s ID.
 This should be reflected in the default behavior.
 
 **Best practices & common pitfalls**
@@ -453,5 +455,5 @@ The Participant Query Store (PQS) is recommended for querying ledger data.
 | http://localhost:5003         | Validator API service                |
 +-------------------------------+--------------------------------------+
 
-In `DevNet` mode, Super Validator and wallet services are hosted externally rather than locally. 
+In `DevNet` mode, Super Validator and wallet services are hosted externally rather than locally.
 The exact URLs for those services are provided by your sponsoring Super Validator.

--- a/sdk/docs/sharable/sdk/quickstart/upgrade/upgrades-on-global-sync.rst
+++ b/sdk/docs/sharable/sdk/quickstart/upgrade/upgrades-on-global-sync.rst
@@ -1,3 +1,7 @@
+:orphan:
+
+.. todo: https://github.com/digital-asset/cn-quickstart/issues/144 -- determine whether and what to keep
+
 Upgrades on the Global Synchronizer
 ===================================
 
@@ -13,41 +17,41 @@ Upgrades on the Global Synchronizer
 
    `Preparing for upgrades <#preparing-for-upgrades>`__
 
-The SVs periodically implement upgrades to the Global Synchronizer to improve functionality, resolve issues, and introduce new features. 
+The SVs periodically implement upgrades to the Global Synchronizer to improve functionality, resolve issues, and introduce new features.
 As a node operator or application provider you should be aware of the three types of upgrades that may occur.
 
 Type 1: backward-compatible changes
 -----------------------------------
 
-Type 1 upgrades involve backward-compatible changes to the Splice applications and/or modifications to the behavior of the Canton synchronization layer. 
+Type 1 upgrades involve backward-compatible changes to the Splice applications and/or modifications to the behavior of the Canton synchronization layer.
 These non-breaking changes occur on Mondays, every week.
 
-While validators can operate effectively when behind by a Splice version or two, the SVs recommend keeping your node up to date with weekly upgrades. 
+While validators can operate effectively when behind by a Splice version or two, the SVs recommend keeping your node up to date with weekly upgrades.
 It's worth noting that "skip upgrades" (jumping multiple versions at once) are not officially tested by the SVs, so while they generally work, they come with increased risk.
 
 Type 2: Daml model changes
 --------------------------
 
-Type 2 upgrades modify the Daml models that underlie the Splice applications. 
+Type 2 upgrades modify the Daml models that underlie the Splice applications.
 These changes introduce a fork in the application chains and occur every few months.
 
 The process for Type 2 upgrades begins with distribution of the new Daml models through Type 1 upgrades, followed by an offline Canton Improvement Proposal (CIP) that must be approved by the SV node owners.
-Next, the SVs conduct an onchain vote to establish a specific date and time when the new models take effect. 
-At this cutoff point, only validators running the most recent Splice version are able to participate in transactions using the new models. 
+Next, the SVs conduct an onchain vote to establish a specific date and time when the new models take effect.
+At this cutoff point, only validators running the most recent Splice version are able to participate in transactions using the new models.
 Validators that haven't adopted the latest version are unable to participate in transactions.
 
 Type 3: non-compatible protocol changes
 ---------------------------------------
 
-Type 3 upgrades involve fundamental changes to the Canton synchronization protocol. 
+Type 3 upgrades involve fundamental changes to the Canton synchronization protocol.
 These major upgrades require downtime (sometimes called Hard Migrations) and occur every three to four months.
 
-The implementation of Type 3 upgrades requires a Canton Improvement Proposal (CIP) approved through an offchain vote, followed by an onchain vote by the SVs to schedule the upgrade. 
-These migrations impact all SVs and Validators, requiring a coordinated transition from the prior protocol to the new one. 
+The implementation of Type 3 upgrades requires a Canton Improvement Proposal (CIP) approved through an offchain vote, followed by an onchain vote by the SVs to schedule the upgrade.
+These migrations impact all SVs and Validators, requiring a coordinated transition from the prior protocol to the new one.
 Currently, Canton requires all nodes to migrate together during these upgrades.
 
 Preparing for upgrades
 ----------------------
 
-Application providers should maintain nodes on DevNet, TestNet, and MainNet to guarantee smooth operations during upgrades. 
+Application providers should maintain nodes on DevNet, TestNet, and MainNet to guarantee smooth operations during upgrades.
 By maintaining nodes across all three environments you substantially increase the likelihood that MainNet upgrades proceed without disrupting your services or customers.


### PR DESCRIPTION
Companion PR to https://github.com/DACH-NY/docs-website/pull/451

(Sorry for the removal of the trailing whitespace -- editor is auto-configured to do that. Best review hiding the whitespace changes.)

The work to add support for a local build with the `:wip:` marker is tracked here:
- https://github.com/digital-asset/cn-quickstart/issues/146