### PR TITLE
docs: fixes broken url in exploring the demo

### DIFF
--- a/sdk/docs/sharable/sdk/quickstart/download/cnqs-installation.rst
+++ b/sdk/docs/sharable/sdk/quickstart/download/cnqs-installation.rst
@@ -62,9 +62,11 @@ This guide walks through the installation and `LocalNet` deployment of the CN QS
 Prerequisites
 =============
 
-Access to the `CN-Quickstart Github repository <https://github.com/digital-asset/cn-quickstart>`__ 
+Access to the open source `CN-Quickstart Github repository <https://github.com/digital-asset/cn-quickstart>`__ 
 and `CN Docker repository <https://digitalasset.jfrog.io/ui/native/canton-network-docker>`__
 is needed to successfully pull the Digital Asset artifacts from JFrog Artifactory.
+
+If you need access to the JFrog Artifactory, email support@digitalasset.com.
 
 Access to the *Daml-VPN* connection or `a SV Node <https://docs.dev.sync.global/validator_operator/validator_onboarding.html>`__
 that is whitelisted on the CN is required to connect to DevNet. 
@@ -165,7 +167,6 @@ Replace `<username>` with the JFrog Artifactory user profile email.
 
 .. image:: images/02-jfrog-user-profile.png
    :alt: JFrog user profile
-   :width: 50%
 
 Create an Identity Token
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -174,20 +175,17 @@ Toward the bottom of the same profile page, click "Generate an Identity Token."
 
 .. image:: images/03-generate-jfrog-token.png
    :alt: JFrog generate identity token
-   :width: 30%
 
 Add an identity token description.
 
 .. image:: images/03b-gen-id-token.png
    :alt: JFrog API Key
-   :width: 30%
 
 Copy the Identity Token as shown under "Reference Token." 
 The Identity Token is also referred to as the "Reference Token" and the "API key" in JFrog and is the password in `~/.netrc`.
 
 .. image:: images/03c-copy-ref-token.png
    :alt: New Reference Token
-   :width: 30%
 
 Complete ~/.netrc
 ~~~~~~~~~~~~~~~~~

--- a/sdk/docs/sharable/sdk/quickstart/operate/explore-the-demo.rst
+++ b/sdk/docs/sharable/sdk/quickstart/operate/explore-the-demo.rst
@@ -28,12 +28,14 @@ Explore the Canton Network quickstart demo
 
 `Next Steps <#next-steps>`__
 
+.. _exploring-the-demo:
+
 Exploring the demo
 ==================
 
 .. wip::
 
-As a result, the CN QS guides may not be a little out of step with the application.
+As a result, the CN QS guides may be a little out of step with the application.
 If you find errors or other inconsistencies, please contact your representative at Digital Asset.
 
 This section works through a complete business operation within the CN QS.
@@ -41,11 +43,13 @@ This section works through a complete business operation within the CN QS.
 Prerequisites
 =============
 
-You should have successfully `installed the CN QS <https://github.com/digital-asset/cn-quickstart/blob/main/docs/guide/CN-QS-Installation-20250314.pdf>`__
+You should have successfully `installed the CN QS <../download/cnqs-installation.html>`__
 before beginning this demonstration.
 
-Access to the `CN-Quickstart Github repository <https://github.com/digital-asset/cn-quickstart>`__ and `CN Docker repository <https://digitalasset.jfrog.io/ui/native/canton-network-docker>`__
+Access to the `CN Docker repository <https://digitalasset.jfrog.io/ui/native/canton-network-docker>`__
 is needed to successfully pull the Digital Asset artifacts from JFrog Artifactory.
+
+If you need support accessing the JFrog Artifactory, please email support@digitalasset.com.
 
 Access to the *Daml-VPN* connection or `a SV Node <https://docs.dev.sync.global/validator_operator/validator_onboarding.html>`__
 that is whitelisted on the CN is required to connect to `DevNet`.
@@ -93,7 +97,6 @@ Select “AppInstalls” in the menu.
 
 .. image:: images/02a-app-installs-view.png
    :alt: App Installs view
-   :width: 60%
 
 Open a terminal.
 
@@ -119,13 +122,11 @@ Click “Accept”.
 
 .. image:: images/06-install-request.png
    :alt: install request
-   :width: 60%
 
 The `AppInstallRequest` is Accepted. The actions update to create or cancel the license.
 
 .. image:: images/07-req-accept.png
    :alt: accept request
-   :width: 60%
 
 Click “Create License”.
 
@@ -133,13 +134,11 @@ The license is created and the “# Licenses” field is updated.
 
 .. image:: images/08-create-lic.png
    :alt: create license
-   :width: 60%
 
 In the `AppProvider`, “Pat the provider’s,” account, navigate to the **Licenses** menu and select “Actions.”
 
 .. image:: images/09-licenses-view.png
    :alt: Licenses view
-   :width: 60%
 
 An “Actions for License” modal opens with an option to renew or expire the license.
 Per the Daml contract, licenses are created in an expired state.
@@ -157,13 +156,11 @@ The license renewal process is initiated and ultimately successful.
 
 .. image:: images/12-init-renewal.png
    :alt: license renewal
-   :width: 60%
 
 The license is now available for a 30-day extension for a flat fee of $100 CC.
 
 .. image:: images/13-license-available.png
    :alt: license available
-   :width: 60%
 
 Pat the provider has done as much as they are able until Alice pays the renewal fee.
 
@@ -187,7 +184,6 @@ Go to the **Licenses** View and click the “Pay renewal” button.
 
 .. image:: images/15-license-view.png
    :alt: License view
-   :width: 60%
 
 Click on the Pay Renewal button. This navigates to the Canton Coin Wallet log in. Click “LOG IN WITH OAUTH2”.
 
@@ -195,7 +191,6 @@ Click on the Pay Renewal button. This navigates to the Canton Coin Wallet log in
 
 .. image:: images/16-cc-wallet-login.png
    :alt: CC Wallet login
-   :width: 30%
 
 This navigates to a keycloak login.
 
@@ -203,7 +198,7 @@ Enter the same username and password as before.
 
 .. image:: images/17-keycloak-login.png
    :alt: alice login
-   :width: 30%
+   :width: 60%
 
 Signing in directs to a preloaded Canton Coin Wallet.
 Click **Send Payment**.
@@ -216,19 +211,16 @@ The `AppProvider` may now Complete the Renewal.
 
 .. image:: images/22-complete-renewal.png
    :alt: complete renewal
-   :width: 50%
 
 Clicking “Complete Renewal” results in a Success.
 
 .. image:: images/23-renew-success.png
    :alt: renewal success
-   :width: 50%
 
 Alice’s License view shows the activated license.
 
 .. image:: images/24-activated-license.png
    :alt: Activated license
-   :width: 50%
 
 Congratulations. You’ve successfully created and activated a license with a payment transfer!
 
@@ -292,7 +284,6 @@ Shows unique identifiers and the asset count
 
 .. image:: images/28-shell-ids.png
    :alt: Active identifiers
-   :width: 50%
 
 `active quickstart-licensing:Licensing.License:License`
 
@@ -300,7 +291,6 @@ List the license details.
 
 .. image:: images/29-license-details.png
    :alt: License details
-   :width: 60%
 
 `active quickstart-licensing:Licensing.License:LicenseRenewalRequest`
 
@@ -312,7 +302,6 @@ Shows any archived license(s).
 
 .. image:: images/30-archive-licenses.png
    :alt: Archived licenses
-   :width: 60%
 
 Connect to DevNet
 -----------------
@@ -351,7 +340,6 @@ For example, if the SV Node Information shows the `migration_id` value as “0�
 
 .. image:: images/32-gsf-sv.png
    :alt: GSF SV information
-   :width: 50%
 
 In `.env`:
 
@@ -400,13 +388,11 @@ Select the Network Info menu to view SV identification.
 
 .. image:: images/34-active-svs.png
    :alt: Active SVs
-   :width: 50%
 
 The Validators menu shows that the local validator has been registered with the SV.
 
 .. image:: images/37-registered-validator.png
    :alt: Registered validator
-   :width: 50%
 
 Observability Dashboard
 -----------------------
@@ -416,20 +402,17 @@ the observability dashboards. Select “Quickstart - consolidated logs”.
 
 .. image:: images/38-obs-dash.png
    :alt: observability dashboard
-   :width: 55%
 
 The default view shows a running stream of all services.
 
 .. image:: images/39-service-stream.png
    :alt: service stream
-   :width: 55%
 
 Change the services filter from “All” to “participant” to view participant logs.
 Select any log entry to view its details.
 
 .. image:: images/40-log-entry-details.png
    :alt: log entry details
-   :width: 60%
 
 SV UIs
 ------
@@ -441,19 +424,16 @@ Login as ‘administrator’.
 
 .. image:: images/33-sv-ui-login.png
    :alt: SV UI login
-   :width: 30%
 
 The UI shows information about the SV and lists the active SVs.
 
 .. image:: images/34-active-svs.png
    :alt: Active SVs
-   :width: 45%
 
 The Validator Onboarding menu allows for the creation of validator onboarding secrets.
 
 .. image:: images/35-validator-onboarding.png
    :alt: Validator onboarding
-   :width: 45%
 
 Next steps
 ==========


### PR DESCRIPTION
Fixes broken URL to the CN QS Installation component how-to in the Exploring the Demo tutorial.
Removes several of the image width properties.