### PR TITLE
docs: name the Java SDK in FAQ, README, cnqs install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,19 @@ Once you are familiar with the QS, please review the technology choices and the 
 
 ## Docs and guides
 
-If you are impatient, then you can start by following the Engineer Setup below. Alternatively, you can peruse the documentation:
-- [Quickstart Installation](docs/guide/CN-QS-Installation-20250516.pdf)
-- [Exploring The Demo](docs/guide/ExploringTheDemo-20250516.pdf)
-- [Project Structure](docs/guide/ProjectStructureGuide-20250317.pdf)
-- [FAQ](docs/guide/CN-QS-FAQ-20250516.pdf)
-- [Observability and Troubleshooting Overview](docs/guide/ObservabilityTroubleshootingOverview-20250220.pdf)
+You can find Quickstart documentation in the Canton Network documentation portal.
+- [Quickstart Installation](https://docs.digitalasset.com/build/3.3/quickstart/download/cnqs-installation)
+- [Exploring The Demo](https://docs.digitalasset.com/build/3.3/quickstart/operate/explore-the-demo)
+- [Project Structure](https://docs.digitalasset.com/build/3.3/quickstart/configure/project-structure-overview)
+- [FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)
+- [Observability and Troubleshooting Overview](https://docs.digitalasset.com/build/3.3/quickstart/observe/observability-troubleshooting-overview.html)
 
 ### Technical documentation
 
 - [Observability](sdk/docs/user/001-observability.md)
 - [Topology](sdk/docs/user/002-topology.md)
 
-Additional documentation and updates are planned weekly.
-
-This project will be rapidly enhanced, so please check back often for updates.
+This project is rapidly enhanced, so please check back often for updates.
 
 ## Engineer setup
 
@@ -88,13 +86,17 @@ $ make console-app-provider
 $ make shell
 ```
 
-If containers fail to start, ensure docker compose is configured to allocate enough memory (recommended minimum total of 32gb).
+If containers fail to start, ensure docker compose is configured to allocate enough memory (recommended minimum total of 8gb).
 
 When running `make start` for the first time, an assistant will help you setting up the local deployment. You can choose to run the application in `DevNet` or `LocalNet` mode (recommended) for local development and testing, the latter meaning that a transient Super Validator is set up locally. You can change this later by running `make setup`.
 
 In `DevNet` mode, you can configure a non-default `SPONSOR_SV_ADDRESS`, `SCAN_ADDRESS` and `ONBOARDING_SECRET_URL` or `ONBOARDING_SECRET` in the `quickstart/.env` file.
 
 **Note**: Access to the Super Validator endpoints on DevNet may require a VPN setup.
+
+**Note**: The CN QS uses Java SDK version `Eclipse Temurin JDK version 17.0.12+7`.
+The Java SDK runs within the Docker container.
+This information is specified in `quickstart/compose.yaml` and `.env`.
 
 ## Available make targets
 

--- a/sdk/docs/sharable/sdk/quickstart/download/cnqs-installation.rst
+++ b/sdk/docs/sharable/sdk/quickstart/download/cnqs-installation.rst
@@ -255,6 +255,9 @@ The Daml SDK is large and can take several minutes to complete.
 .. image:: images/06-unpack-sdk.png
    :alt: Daml SDK unpacking
 
+.. note:: The CN QS uses Java SDK version `Eclipse Temurin JDK version 17.0.12+7`.
+   The Java SDK runs within the Docker container.
+
 Deploy a validator on LocalNet
 ------------------------------
 

--- a/sdk/docs/sharable/sdk/quickstart/troubleshoot/cnqs-faq.rst
+++ b/sdk/docs/sharable/sdk/quickstart/troubleshoot/cnqs-faq.rst
@@ -116,6 +116,27 @@ The gradle daemon has been disabled to prevent parallel processing of transcodeg
 Gradle tasks had been known to create order and concurrency issues which caused files to get cleaned too early.
 Always prefer to use the make commands.
 
+**What version of the Java SDK does the CN Quickstart use?**
+
+The CN QS uses Java SDK version `Eclipse Temurin JDK version 17.0.12+7`.
+The Java SDK runs within the Docker container.
+
+This information is specified in `quickstart/compose.yaml` and `.env`, respectively.
+
+`quickstart/compose.yaml`
+
+::
+
+   services:
+   backend-service:
+      image: "eclipse-temurin:${JAVA_VERSION}"
+   
+`.env`
+
+::
+
+   JAVA_VERSION=17.0.12_7-jdk
+
 **How do I resolve a “build failed with an exception failure”?**
 
 If `make install-daml-sdk` results in:
@@ -150,10 +171,9 @@ To resolve this error, copy the faulty `.tar.gz` file with directory path as sho
 
 ::
 
-   rm
-   /Users/USER/Code/cn-quickstart/quickstart/daml/.sdk/daml-sdk-3.2.0-snapshot.20241031.13398.0.vf95d2607-macos-x86_64-ee.tar.gz
+   rm /Users/USER/Code/cn-quickstart/quickstart/daml/.sdk/daml-sdk-3.2.0-snapshot.20241031.13398.0.vf95d2607-macos-x86_64-ee.tar.gz
 
-💡 USER in /Users/USER/ will display your username. Copy and paste from your terminal. NOT this FAQ.
+.. note:: `USER` in `/Users/USER/` will display your username. Copy and paste from your terminal. NOT this FAQ.
 
 Reattempt make install-daml-sdk.
 


### PR DESCRIPTION
Cleans up README
* Updates PDF guide links with Docs portal links
* Names the Java SDK in the Docker container

Also names Java SDK specification in FAQ and CN QS installation guide.