### PR TITLE
Fix 04-quickstart-top-level-dir toplevel header.

### DIFF
--- a/sdk/docs/sharable/sdk/quickstart/configure/quickstart-project-structure/04-quickstart-top-level-dir.rst
+++ b/sdk/docs/sharable/sdk/quickstart/configure/quickstart-project-structure/04-quickstart-top-level-dir.rst
@@ -1,5 +1,5 @@
 Quickstart top-level directory structure
-=======================================
+========================================
 
 Quickstart project directory
 ----------------------------


### PR DESCRIPTION
Missing '=' from toplevel header preventing sphinx from compiling 04-quickstart-toplevel.