### PR TITLE
Set sslRequired to none in keycloak configuration files

### DIFF
--- a/quickstart/docker/modules/keycloak/conf/data/AppProvider-realm.json
+++ b/quickstart/docker/modules/keycloak/conf/data/AppProvider-realm.json
@@ -28,7 +28,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "none",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,

--- a/quickstart/docker/modules/keycloak/conf/data/AppUser-realm.json
+++ b/quickstart/docker/modules/keycloak/conf/data/AppUser-realm.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "none",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,


### PR DESCRIPTION
## Changes
- change sslRequired in Keycloak configuration from external to none to disable any HTTPS requirements 