### PR TITLE
configure playwright to keep trace on failure

### DIFF
--- a/quickstart/integration-test/playwright.config.ts
+++ b/quickstart/integration-test/playwright.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
     navigationTimeout: 30_000,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
   },
 
   projects: [


### PR DESCRIPTION
configure playwright to keep trace on failure even if there are no retries