### PR TITLE
Update canton console target in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ make build
 $ make start
 
 # In a separate shell - run a Canton Console for the App Provider
-$ make console-app-provider
+$ make canton-console
 
 # In a separate shell - run Daml Shell
 $ make shell


### PR DESCRIPTION
The readme is out of date compared to the Makefile since f952e1b9762a36af725b1a1ffa8d21f3e7ed435a. Namely, the `console-app-provider` is now `canton-console`.