### PR TITLE
Add the logs directory to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ gradle-app.setting
 
 # direnv
 .direnv/
+
+logs


### PR DESCRIPTION
The `logs` directory ends up with a lot of junk after just a little bit of usage in the repo, and that's not helping anyone.

Add `logs` to `.gitignore` to avoid future calamity.