### PR TITLE
add gcloud via nix

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -13,6 +13,7 @@ let
     python3
     (vale.withStyles (styles: [ styles.google ]))
   ] else [ # these packages are only installed on developer machines locally
+    google-cloud-sdk
   ]));
 in
 pkgs.mkShell {


### PR DESCRIPTION
`gcloud` seems to be required to make docker credential helper happy

Add it for now to get full experience working.

As follow-on -- investigate whether we can get docker images from europe-docker.pkg.dev working without gcloud