### PR TITLE
docs: bump directory tree in quickstart guide

### DIFF
--- a/sdk/docs/sharable/sdk/quickstart/configure/development-lifecycle.rst
+++ b/sdk/docs/sharable/sdk/quickstart/configure/development-lifecycle.rst
@@ -103,9 +103,9 @@ to learn from the CN Quickstart while building their own application.
    │ └── frontend/    # Original frontend
    │
    └── myapp/         # Your application code
-   ├── daml/          # Your Daml models
-   ├── backend/       # Your backend services
-   └── frontend/      # Your frontend code
+     ├── daml/        # Your Daml models
+     ├── backend/     # Your backend services
+     └── frontend/    # Your frontend code
 
 Developers may generate new Daml packages, new client code in languages
 other than Java or TypeScript, UI elements, CI/CD integration, and unit


### PR DESCRIPTION
This make it (more) clear that the daml/, backend/ and frontend/ directories should be nested under myapp/.