### PR TITLE
Remove scalapb dependency

### DIFF
--- a/quickstart/backend/build.gradle.kts
+++ b/quickstart/backend/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     implementation(Deps.transcode.protoJson)
 
     protobuf(Deps.daml.proto)
-    protobuf(Deps.daml.scalapb)
     protobuf(Deps.grpc.commonsProto)
     implementation(Deps.grpc.stub)
     implementation(Deps.grpc.protobuf)

--- a/quickstart/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/quickstart/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,6 @@ object Deps {
     object daml {
         val version get() = VersionFiles.dotenv["DAML_RUNTIME_VERSION"]
         val proto get() = "com.daml:ledger-api-proto:$version"
-        val scalapb get() = "com.thesamet.scalapb:scalapb-runtime_2.13:0.11.14"
     }
 
     object grpc {


### PR DESCRIPTION
We should not need the `scalapb` dependency to generate Java classes from proto files

This issue was fixed upstream in https://github.com/digital-asset/daml/pull/22371