### PR TITLE
Add Node.js example for Canton JSON Ledger v2 + PQS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ An assistant helps set up deployment when running `make start` for the first tim
 You can choose to run the application in standard mode or test mode and with or without OAUTH2. 
 You may change this later by running `make setup`.
 
+### Node.js example (TypeScript bindings + JSON Ledger v2)
+
+A minimal worked example using `@canton-network/core-ledger-client` (JSON
+Ledger API v2) and `dpm codegen-js` typed bindings lives at
+[`quickstart/examples/node-happy-path/`](quickstart/examples/node-happy-path/).
+Useful as a starting point for Node-shop teams building against Canton.
+See its README for run instructions.
+
 ## Debugging TL;DR
 
 If a container fails to start, there are a few things to try:

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,7 +6,8 @@ let
     coreutils # provides gdate command needed by Makefile for Docker log timestamp formatting on macOS
     dpm
     jdk21
-    nodejs_20
+    nodejs_22
+    nodePackages.pnpm
     typescript
   ] ++ (if ci then [ # these packages should only be installed on CI
     circleci-cli

--- a/quickstart/examples/.gitignore
+++ b/quickstart/examples/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.cache/
+*.log
+.DS_Store
+# `pnpm codegen:daml` (in node-happy-path) generates a workspace.
+# Regenerated from the DARs on every build — do not commit.
+node-happy-path/daml-bindings/

--- a/quickstart/examples/node-happy-path/README.md
+++ b/quickstart/examples/node-happy-path/README.md
@@ -1,0 +1,103 @@
+# node-happy-path
+
+Smallest Node.js script that talks to Canton end-to-end. Targets
+[#156][156] and [#59][59]: a developer who's never written against Canton
+from Node should be able to read this and have a working mental model in
+minutes — not hours.
+
+[156]: https://github.com/digital-asset/cn-quickstart/issues/156
+[59]: https://github.com/digital-asset/cn-quickstart/issues/59
+
+`src/index.ts` is ~135 lines and shows, in order:
+
+1. Mint a shared-secret JWT with the claim shape Canton's ledger API expects.
+2. Build a `LedgerClient` from `@canton-network/core-ledger-client`.
+3. Read active `AppInstall` contracts from the PQS Postgres replica.
+4. Exercise `AppInstall_CreateLicense` via JSON Ledger API v2 — the
+   choice argument is type-checked against the `dpm codegen-js` output,
+   so a typo in `params`, `meta`, or `values` is a compile error.
+5. Confirm the new `License` contract appears in PQS.
+
+No DI, no Express, no OpenAPI router — by design. The point is to put
+the moving parts on one screen.
+
+## Prerequisites
+
+- Node.js 22 LTS
+- pnpm 9+ (`corepack enable && corepack prepare pnpm@9 --activate`)
+- `dpm` on PATH (installed by `make build-daml` from `quickstart/`)
+
+## Run it
+
+The script needs the cn-quickstart stack running in **shared-secret**
+auth mode. From `quickstart/`:
+
+```bash
+make setup     # choose AUTH_MODE=shared-secret when prompted
+make build     # builds the Daml DARs and other artifacts
+make start     # brings up the stack
+```
+
+Then complete one onboarding flow in the UI so an `AppInstall` contract
+exists.
+
+Build the example:
+
+```bash
+cd quickstart/examples/node-happy-path
+pnpm codegen:daml         # dpm codegen-js → daml-bindings/
+pnpm install              # picks up the workspace packages
+```
+
+Read the runtime values from the running stack:
+
+```bash
+# AppProvider party — populated by splice-onboarding inside the
+# backend-service container.
+APP_PROVIDER_PARTY_ID="$(docker compose exec -T backend-service \
+  sh -c '. /onboarding/backend-service/on/app-provider.sh && \
+         printf %s "$APP_PROVIDER_PARTY"')"
+
+# Shared secret — whatever you configured when running `make setup`
+# in shared-secret mode.
+AUTH_SHARED_SECRET="<your-shared-secret-from-make-setup>"
+```
+
+Run:
+
+```bash
+LEDGER_API_URL=http://canton.localhost:3975 \
+PQS_DATABASE_URL='postgresql://cnadmin:supersafe@localhost:5432/scribe' \
+AUTH_SHARED_SECRET="$AUTH_SHARED_SECRET" \
+APP_PROVIDER_PARTY_ID="$APP_PROVIDER_PARTY_ID" \
+pnpm start
+```
+
+Expected output:
+
+```
+{"level":30,"msg":"minted shared-secret token"}
+{"level":30,"baseUrl":"http://canton.localhost:3975","msg":"ledger client ready"}
+{"level":30,"count":1,"msg":"active AppInstall contracts visible to provider"}
+{"level":30,"contractId":"00...","msg":"exercising AppInstall_CreateLicense"}
+{"level":30,"newLicenseCid":"00...","msg":"created License"}
+{"level":30,"visibleInPqs":true,"msg":"PQS round-trip confirmation"}
+{"level":30,"msg":"done"}
+```
+
+## Why a shared-secret JWT?
+
+Self-signing keeps the example to one file. Real deployments use OIDC.
+
+## What this intentionally glosses over
+
+| Gloss | What a production caller would do |
+|---|---|
+| Bare PQS access via the `pg` driver | Wrap `active(template_id)` queries in a small repository layer with codegen-typed payloads |
+| OAuth2 / multi-issuer JWT verification | Verify per-issuer JWKS, resolve party by `iss` claim, fall through to a tenant registry |
+| Token Standard registry HTTP (renewals, allocations) | Use `@canton-network/core-token-standard` for choice contexts and registry calls |
+| Cross-cut logging / OTel | Wire `@opentelemetry/sdk-node` before any `pg`/`http`/`express` import |
+| Disclosed-contract forwarding on `exerciseChoice` | Pass `disclosedContracts` from the choice context onto `JsCommands` |
+
+Each row is a real edge of the API a developer would otherwise hit by
+trial and error. This script gets past line 1 so the rest is approachable.

--- a/quickstart/examples/node-happy-path/package.json
+++ b/quickstart/examples/node-happy-path/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@cn-quickstart/example-node-happy-path",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Minimal Node.js happy-path against Canton JSON Ledger v2 + PQS, using dpm-codegen TypeScript bindings.",
+  "packageManager": "pnpm@9.15.0",
+  "scripts": {
+    "codegen:daml": "./scripts/codegen-daml.sh",
+    "start": "node --enable-source-maps --import=tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@canton-network/core-ledger-client": "^1.1.1",
+    "@canton-network/core-wallet-auth": "^1.1.1",
+    "@daml.js/quickstart-licensing-0.0.1": "workspace:*",
+    "@daml/types": "3.4.11",
+    "jose": "^5.9.6",
+    "pg": "^8.13.1",
+    "pino": "^9.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "@types/pg": "^8.11.10",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.0"
+  }
+}

--- a/quickstart/examples/node-happy-path/pnpm-lock.yaml
+++ b/quickstart/examples/node-happy-path/pnpm-lock.yaml
@@ -1,0 +1,1180 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@canton-network/core-ledger-client':
+        specifier: ^1.1.1
+        version: 1.1.1
+      '@canton-network/core-wallet-auth':
+        specifier: ^1.1.1
+        version: 1.1.1
+      '@daml.js/quickstart-licensing-0.0.1':
+        specifier: workspace:*
+        version: link:daml-bindings/quickstart-licensing-0.0.1
+      '@daml/types':
+        specifier: 3.4.11
+        version: 3.4.11
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
+      pg:
+        specifier: ^8.13.1
+        version: 8.20.0
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.17
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+
+  daml-bindings/daml-prim-DA-Exception-ArithmeticError-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-prim-DA-Exception-AssertionFailed-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-prim-DA-Exception-GeneralError-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-prim-DA-Exception-PreconditionFailed-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-prim-DA-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-prim-GHC-Tuple-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-prim-GHC-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Date-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Internal-Down-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Logic-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Monoid-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-NonEmpty-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Random-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Semigroup-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Set-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Stack-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Time-Types-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/daml-stdlib-DA-Validation-Types-1.0.0:
+    dependencies:
+      '@daml.js/daml-stdlib-DA-NonEmpty-Types-1.0.0':
+        specifier: file:../daml-stdlib-DA-NonEmpty-Types-1.0.0
+        version: link:../daml-stdlib-DA-NonEmpty-Types-1.0.0
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/ghc-stdlib-DA-Internal-Template-1.0.0:
+    dependencies:
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/quickstart-licensing-0.0.1:
+    dependencies:
+      '@daml.js/daml-stdlib-DA-Time-Types-1.0.0':
+        specifier: file:../daml-stdlib-DA-Time-Types-1.0.0
+        version: link:../daml-stdlib-DA-Time-Types-1.0.0
+      '@daml.js/ghc-stdlib-DA-Internal-Template-1.0.0':
+        specifier: file:../ghc-stdlib-DA-Internal-Template-1.0.0
+        version: link:../ghc-stdlib-DA-Internal-Template-1.0.0
+      '@daml.js/splice-api-token-allocation-request-v1-1.0.0':
+        specifier: file:../splice-api-token-allocation-request-v1-1.0.0
+        version: link:../splice-api-token-allocation-request-v1-1.0.0
+      '@daml.js/splice-api-token-allocation-v1-1.0.0':
+        specifier: file:../splice-api-token-allocation-v1-1.0.0
+        version: link:../splice-api-token-allocation-v1-1.0.0
+      '@daml.js/splice-api-token-holding-v1-1.0.0':
+        specifier: file:../splice-api-token-holding-v1-1.0.0
+        version: link:../splice-api-token-holding-v1-1.0.0
+      '@daml.js/splice-api-token-metadata-v1-1.0.0':
+        specifier: file:../splice-api-token-metadata-v1-1.0.0
+        version: link:../splice-api-token-metadata-v1-1.0.0
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/splice-api-token-allocation-request-v1-1.0.0:
+    dependencies:
+      '@daml.js/ghc-stdlib-DA-Internal-Template-1.0.0':
+        specifier: file:../ghc-stdlib-DA-Internal-Template-1.0.0
+        version: link:../ghc-stdlib-DA-Internal-Template-1.0.0
+      '@daml.js/splice-api-token-allocation-v1-1.0.0':
+        specifier: file:../splice-api-token-allocation-v1-1.0.0
+        version: link:../splice-api-token-allocation-v1-1.0.0
+      '@daml.js/splice-api-token-metadata-v1-1.0.0':
+        specifier: file:../splice-api-token-metadata-v1-1.0.0
+        version: link:../splice-api-token-metadata-v1-1.0.0
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/splice-api-token-allocation-v1-1.0.0:
+    dependencies:
+      '@daml.js/ghc-stdlib-DA-Internal-Template-1.0.0':
+        specifier: file:../ghc-stdlib-DA-Internal-Template-1.0.0
+        version: link:../ghc-stdlib-DA-Internal-Template-1.0.0
+      '@daml.js/splice-api-token-holding-v1-1.0.0':
+        specifier: file:../splice-api-token-holding-v1-1.0.0
+        version: link:../splice-api-token-holding-v1-1.0.0
+      '@daml.js/splice-api-token-metadata-v1-1.0.0':
+        specifier: file:../splice-api-token-metadata-v1-1.0.0
+        version: link:../splice-api-token-metadata-v1-1.0.0
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/splice-api-token-holding-v1-1.0.0:
+    dependencies:
+      '@daml.js/daml-stdlib-DA-Time-Types-1.0.0':
+        specifier: file:../daml-stdlib-DA-Time-Types-1.0.0
+        version: link:../daml-stdlib-DA-Time-Types-1.0.0
+      '@daml.js/ghc-stdlib-DA-Internal-Template-1.0.0':
+        specifier: file:../ghc-stdlib-DA-Internal-Template-1.0.0
+        version: link:../ghc-stdlib-DA-Internal-Template-1.0.0
+      '@daml.js/splice-api-token-metadata-v1-1.0.0':
+        specifier: file:../splice-api-token-metadata-v1-1.0.0
+        version: link:../splice-api-token-metadata-v1-1.0.0
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+  daml-bindings/splice-api-token-metadata-v1-1.0.0:
+    dependencies:
+      '@daml.js/daml-stdlib-DA-Time-Types-1.0.0':
+        specifier: file:../daml-stdlib-DA-Time-Types-1.0.0
+        version: link:../daml-stdlib-DA-Time-Types-1.0.0
+      '@daml.js/ghc-stdlib-DA-Internal-Template-1.0.0':
+        specifier: file:../ghc-stdlib-DA-Internal-Template-1.0.0
+        version: link:../ghc-stdlib-DA-Internal-Template-1.0.0
+      '@mojotech/json-type-validation':
+        specifier: ^3.1.0
+        version: 3.1.0
+
+packages:
+
+  '@canton-network/core-ledger-client-types@1.1.1':
+    resolution: {integrity: sha512-d1S96qPkT7fjR+iJKMEH8NusXouKNKJ4MzZ7V/5bHS128gyhjQOwp3MgrCVr30ttvdctY+4Yj6T16ZgJGJ5Xvw==}
+
+  '@canton-network/core-ledger-client@1.1.1':
+    resolution: {integrity: sha512-CRoee7Mgv1yipEZNx/NOyKjIVcudNCyDVUR0duyGDDE7aAZRk6HJ7OxU+odpAfJCU+Yp+h+R1ZihGItgGWZbNg==}
+
+  '@canton-network/core-ledger-proto@1.1.1':
+    resolution: {integrity: sha512-OpomEr3qEp2LJMv4eyY47qFCgwlDRfhZsP97k4V8jVd6pY6su0KYXPsueEYpmeH/+BV/OeFzYGpigYUhj3j8wA==}
+
+  '@canton-network/core-rpc-errors@1.1.1':
+    resolution: {integrity: sha512-km2MdLWaQ9v1J9w/C9yEu6Dofd5uVeC4dR7vm0Hd3mW3A6BxJzcW2zRef3+c2+9gHpUhikMmDr1TAPhPktYAYA==}
+
+  '@canton-network/core-splice-client@1.1.1':
+    resolution: {integrity: sha512-jzGiwfCmLMdrLKgac3Wo9NcLtitNoMSyjSg1xqGa4d4CRfQgalpNvMzZkGt+ADufkBqiXSBREsc1Snq8lHfa3g==}
+
+  '@canton-network/core-token-standard@1.1.1':
+    resolution: {integrity: sha512-EAhVw0WNDNYWze3TjEbzOocx4A4HoQK5W1zx0MI1CSQf4d8g4tjo4iPlL1PHN6D/SvYlFpO1zgvHxOjvfYYgpg==}
+
+  '@canton-network/core-types@1.1.1':
+    resolution: {integrity: sha512-NFTI6Bq2ce9ja03ejTQLuHyEUjmwQ5LHZnSgO2Svr2Kd6kfbl8uJtjd5dQX7fBpzHLjpj72p0Yai2s+JyFM0MQ==}
+
+  '@canton-network/core-wallet-auth@1.1.1':
+    resolution: {integrity: sha512-M1GZ7fgs+XQVp9kS88sDY94cPYMC+2kO6h0PHa8hNDzcnv5BS4pNRWL4JF8HZNS5kdPKxd/50EtwCofDE2vLLA==}
+
+  '@daml/types@3.4.11':
+    resolution: {integrity: sha512-lGskPPTFVtJpLbHi1XoqG7/mnOU/zJcomQixoszEbtU7D63t7xDAW9yvtaQa7C1Uz70OOBhM1z72Se63GR3NXg==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ethereumjs/common@3.2.0':
+    resolution: {integrity: sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==}
+
+  '@ethereumjs/rlp@4.0.1':
+    resolution: {integrity: sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  '@ethereumjs/tx@4.2.0':
+    resolution: {integrity: sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==}
+    engines: {node: '>=14'}
+
+  '@ethereumjs/util@8.1.0':
+    resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
+    engines: {node: '>=14'}
+
+  '@metamask/rpc-errors@7.0.3':
+    resolution: {integrity: sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==}
+    engines: {node: ^18.20 || ^20.17 || >=22}
+
+  '@metamask/superstruct@3.2.1':
+    resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
+    engines: {node: '>=16.0.0'}
+
+  '@metamask/utils@11.11.0':
+    resolution: {integrity: sha512-0nF2CWjWQr/m0Y2t2lJnBTU1/CZPPTvKvcESLplyWe/tyeb8zFOi/FeneDmaFnML6LYRIGZU6f+xR0jKAIUZfw==}
+    engines: {node: ^18.18 || ^20.14 || >=22}
+
+  '@mojotech/json-type-validation@3.1.0':
+    resolution: {integrity: sha512-ThH2EbHEUCPMHhXAtmYcDi0gmV+PZak4uvuWBMiBDqUuz7gGQUrsE5o1J6kKNLDX5cXAPqsfJ7uTfTcNdCDXxA==}
+    engines: {node: '>=6.0.0'}
+
+  '@noble/curves@1.4.2':
+    resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
+
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    resolution: {integrity: sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==}
+
+  '@protobuf-ts/runtime@2.11.1':
+    resolution: {integrity: sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==}
+
+  '@scure/base@1.1.9':
+    resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.4.0':
+    resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
+
+  '@scure/bip39@1.3.0':
+    resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  bignumber.js@10.0.2:
+    resolution: {integrity: sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  ethereum-cryptography@2.2.1:
+    resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  micro-ftch@0.3.1:
+    resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
+
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
+  pony-cause@2.1.11:
+    resolution: {integrity: sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==}
+    engines: {node: '>=12.0.0'}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript-lru-cache@2.0.0:
+    resolution: {integrity: sha512-Jp57Qyy8wXeMkdNuZiglE6v2Cypg13eDA1chHwDG6kq51X7gk4K7P7HaDdzZKCxkegXkVHNcPD0n5aW6OZH3aA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
+
+snapshots:
+
+  '@canton-network/core-ledger-client-types@1.1.1':
+    dependencies:
+      '@canton-network/core-types': 1.1.1
+      bignumber.js: 10.0.2
+      dayjs: 1.11.20
+      openapi-fetch: 0.17.0
+      pino: 10.3.1
+
+  '@canton-network/core-ledger-client@1.1.1':
+    dependencies:
+      '@canton-network/core-ledger-client-types': 1.1.1
+      '@canton-network/core-ledger-proto': 1.1.1
+      '@canton-network/core-splice-client': 1.1.1
+      '@canton-network/core-token-standard': 1.1.1
+      '@canton-network/core-types': 1.1.1
+      '@canton-network/core-wallet-auth': 1.1.1
+      bignumber.js: 10.0.2
+      dayjs: 1.11.20
+      openapi-fetch: 0.17.0
+      pino: 10.3.1
+      typescript-lru-cache: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@canton-network/core-ledger-proto@1.1.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+
+  '@canton-network/core-rpc-errors@1.1.1':
+    dependencies:
+      '@metamask/rpc-errors': 7.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@canton-network/core-splice-client@1.1.1':
+    dependencies:
+      '@canton-network/core-types': 1.1.1
+      '@canton-network/core-wallet-auth': 1.1.1
+      openapi-fetch: 0.17.0
+      uuid: 14.0.0
+      zod: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@canton-network/core-token-standard@1.1.1':
+    dependencies:
+      '@canton-network/core-types': 1.1.1
+      '@canton-network/core-wallet-auth': 1.1.1
+      lodash: 4.18.1
+      openapi-fetch: 0.17.0
+      uuid: 14.0.0
+      zod: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@canton-network/core-types@1.1.1':
+    dependencies:
+      uuid: 14.0.0
+      zod: 4.4.1
+
+  '@canton-network/core-wallet-auth@1.1.1':
+    dependencies:
+      '@canton-network/core-rpc-errors': 1.1.1
+      '@canton-network/core-types': 1.1.1
+      jose: 6.2.3
+      zod: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@daml/types@3.4.11':
+    dependencies:
+      '@mojotech/json-type-validation': 3.1.0
+      '@types/lodash': 4.17.24
+      lodash: 4.18.1
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@ethereumjs/common@3.2.0':
+    dependencies:
+      '@ethereumjs/util': 8.1.0
+      crc-32: 1.2.2
+
+  '@ethereumjs/rlp@4.0.1': {}
+
+  '@ethereumjs/tx@4.2.0':
+    dependencies:
+      '@ethereumjs/common': 3.2.0
+      '@ethereumjs/rlp': 4.0.1
+      '@ethereumjs/util': 8.1.0
+      ethereum-cryptography: 2.2.1
+
+  '@ethereumjs/util@8.1.0':
+    dependencies:
+      '@ethereumjs/rlp': 4.0.1
+      ethereum-cryptography: 2.2.1
+      micro-ftch: 0.3.1
+
+  '@metamask/rpc-errors@7.0.3':
+    dependencies:
+      '@metamask/utils': 11.11.0
+      fast-safe-stringify: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@metamask/superstruct@3.2.1': {}
+
+  '@metamask/utils@11.11.0':
+    dependencies:
+      '@ethereumjs/tx': 4.2.0
+      '@metamask/superstruct': 3.2.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@types/debug': 4.1.13
+      '@types/lodash': 4.17.24
+      debug: 4.4.3
+      lodash: 4.18.1
+      pony-cause: 2.1.11
+      semver: 7.7.4
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mojotech/json-type-validation@3.1.0':
+    dependencies:
+      lodash.isequal: 4.5.0
+
+  '@noble/curves@1.4.2':
+    dependencies:
+      '@noble/hashes': 1.4.0
+
+  '@noble/hashes@1.4.0': {}
+
+  '@noble/hashes@1.8.0': {}
+
+  '@pinojs/redact@0.4.0': {}
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+
+  '@protobuf-ts/runtime@2.11.1': {}
+
+  '@scure/base@1.1.9': {}
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.4.0':
+    dependencies:
+      '@noble/curves': 1.4.2
+      '@noble/hashes': 1.4.0
+      '@scure/base': 1.1.9
+
+  '@scure/bip39@1.3.0':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      '@scure/base': 1.1.9
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/lodash@4.17.24': {}
+
+  '@types/ms@2.1.0': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.17
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
+  atomic-sleep@1.0.0: {}
+
+  bignumber.js@10.0.2: {}
+
+  crc-32@1.2.2: {}
+
+  dayjs@1.11.20: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  ethereum-cryptography@2.2.1:
+    dependencies:
+      '@noble/curves': 1.4.2
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.3.0
+
+  fast-safe-stringify@2.1.1: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  jose@5.10.0: {}
+
+  jose@6.2.3: {}
+
+  lodash.isequal@4.5.0: {}
+
+  lodash@4.18.1: {}
+
+  micro-ftch@0.3.1: {}
+
+  ms@2.1.3: {}
+
+  on-exit-leak-free@2.1.2: {}
+
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
+  openapi-typescript-helpers@0.1.0: {}
+
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
+
+  pony-cause@2.1.11: {}
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  process-warning@5.0.0: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  real-require@0.2.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  safe-stable-stringify@2.5.0: {}
+
+  semver@7.7.4: {}
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  split2@4.2.0: {}
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript-lru-cache@2.0.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  uuid@14.0.0: {}
+
+  uuid@9.0.1: {}
+
+  xtend@4.0.2: {}
+
+  zod@4.4.1: {}

--- a/quickstart/examples/node-happy-path/pnpm-workspace.yaml
+++ b/quickstart/examples/node-happy-path/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - .
+  - daml-bindings/*

--- a/quickstart/examples/node-happy-path/scripts/codegen-daml.sh
+++ b/quickstart/examples/node-happy-path/scripts/codegen-daml.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Generate TypeScript bindings for the licensing DAR (and its splice
+# Token-Standard transitive deps). Output is one workspace package per
+# input DAR under daml-bindings/, consumed via pnpm-workspace.yaml.
+#
+# Prerequisites:
+#   - dpm on PATH. Installed by `make build-daml` from quickstart/.
+#   - quickstart-licensing-0.0.1.dar built. Same target.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+QUICKSTART_DIR="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+
+OUTPUT_DIR="$EXAMPLE_DIR/daml-bindings"
+
+# Minimum DAR set needed for the AppInstall_CreateLicense path:
+#   - licensing: AppInstall + AppInstall_CreateLicense + License.
+#   - splice-api-token-metadata-v1: MetadataV1.Metadata, referenced by
+#     LicenseParams.meta. Without this, the typed choice argument can't
+#     resolve.
+DARS=(
+  "$QUICKSTART_DIR/daml/licensing/.daml/dist/quickstart-licensing-0.0.1.dar"
+  "$QUICKSTART_DIR/daml/dars/splice-api-token-metadata-v1-1.0.0.dar"
+)
+
+for dar in "${DARS[@]}"; do
+  if [ ! -f "$dar" ]; then
+    echo "ERROR: missing DAR: $dar" >&2
+    echo "Hint: run 'make build-daml' from quickstart/ first." >&2
+    exit 1
+  fi
+done
+
+if ! command -v dpm >/dev/null 2>&1; then
+  echo "ERROR: dpm not on PATH. Install via 'make build-daml' from quickstart/." >&2
+  exit 1
+fi
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+cd "$OUTPUT_DIR"
+dpm codegen-js "${DARS[@]}" -o .
+
+echo "==> Codegen output:"
+ls -1 "$OUTPUT_DIR"
+echo
+echo "==> Done. Run 'pnpm install' to pick up the workspace packages."

--- a/quickstart/examples/node-happy-path/src/index.ts
+++ b/quickstart/examples/node-happy-path/src/index.ts
@@ -1,0 +1,149 @@
+// Canton + Node.js minimal happy path.
+//
+// What this script demonstrates, end-to-end, in one file:
+//   1. Mint a self-signed shared-secret JWT for the Canton ledger API.
+//   2. Build a typed `LedgerClient` against Canton JSON Ledger API v2.
+//   3. Read active `AppInstall` contracts from the PQS Postgres replica.
+//   4. Exercise `AppInstall_CreateLicense` on the first one — argument
+//      shape is type-checked against the `dpm codegen-js` output.
+//   5. Confirm the new `License` lands in PQS.
+//
+// No DI, no Express, no OpenAPI router. The point is to put the moving
+// parts on one screen.
+
+import { LedgerClient } from '@canton-network/core-ledger-client'
+import { AuthTokenProvider } from '@canton-network/core-wallet-auth'
+import { Licensing } from '@daml.js/quickstart-licensing-0.0.1'
+import { SignJWT } from 'jose'
+import { Pool } from 'pg'
+import pino from 'pino'
+
+const log = pino({ level: process.env.LOG_LEVEL ?? 'info' })
+
+function need(key: string): string {
+  const v = process.env[key]
+  if (v === undefined || v === '') {
+    log.error({ key }, 'missing required env')
+    process.exit(1)
+  }
+  return v
+}
+
+const LEDGER_API_URL = need('LEDGER_API_URL')
+const PQS_DATABASE_URL = need('PQS_DATABASE_URL')
+const AUTH_SHARED_SECRET = need('AUTH_SHARED_SECRET')
+const PARTY_ID = need('APP_PROVIDER_PARTY_ID')
+
+// Typed template references from `dpm codegen-js`. They expose a static
+// `templateId` string (prefixed with `#package-name:` per @daml.js
+// convention) plus typed Choice metadata.
+//
+// JSON Ledger API v2 accepts the `#`-prefixed form directly. PQS's
+// `active(template_id)` SQL function requires the prefix stripped — that
+// translation is the only ledger-vs-PQS gotcha you cannot infer from
+// the OpenAPI types alone.
+const { AppInstall } = Licensing.AppInstall
+const { License } = Licensing.License
+const pqsTid = (tid: string): string => tid.replace(/^#/, '')
+
+// 1. Mint a shared-secret JWT with the claim shape Canton's ledger API
+//    accepts in unsafe-secret mode. Production deployments use OIDC.
+const secretBytes = new TextEncoder().encode(AUTH_SHARED_SECRET)
+const token = await new SignJWT({
+  aud: 'https://canton.network.global',
+  sub: 'app-provider',
+  scope: 'daml_ledger_api',
+  party: PARTY_ID,
+})
+  .setProtectedHeader({ alg: 'HS256' })
+  .setIssuedAt()
+  .setExpirationTime('1h')
+  .sign(secretBytes)
+log.info('minted shared-secret token')
+
+// 2. Build a typed LedgerClient. `postWithRetry` is generic over the
+//    JSON v2 OpenAPI paths — typos in the path or body shape fail at
+//    compile time. Works against Canton 3.4 + 3.5.
+const ledger = new LedgerClient({
+  baseUrl: new URL(LEDGER_API_URL),
+  logger: log,
+  accessTokenProvider: AuthTokenProvider.fromToken(token, log),
+  version: '3.4',
+})
+await ledger.init()
+log.info({ baseUrl: LEDGER_API_URL }, 'ledger client ready')
+
+// 3. Read PQS. The `active(template_id)` SQL function returns the
+//    currently-active contracts for the given template. PQS is a
+//    Postgres materialized view of the ledger maintained by Scribe —
+//    far cheaper to query for list views than the JSON ACS endpoint.
+const pg = new Pool({ connectionString: PQS_DATABASE_URL })
+const { rows: installs } = await pg.query<{
+  contract_id: string
+  payload: { provider: string; user: string }
+}>("SELECT contract_id, payload FROM active($1) WHERE payload->>'provider' = $2", [
+  pqsTid(AppInstall.templateId),
+  PARTY_ID,
+])
+log.info({ count: installs.length }, 'active AppInstall contracts visible to provider')
+if (installs.length === 0) {
+  log.warn('no AppInstalls — start the stack and accept an AppUser onboarding flow first')
+  await pg.end()
+  process.exit(0)
+}
+
+// 4. Exercise AppInstall_CreateLicense. The argument is typed against
+//    the codegen'd `AppInstall_CreateLicense` shape: `{ params:
+//    LicenseParams }` where `LicenseParams.meta` is the splice
+//    MetadataV1.Metadata `{ values: TextMap }`. A typo in `params`,
+//    `meta`, or `values` is a compile error.
+const target = installs[0]
+if (target === undefined) throw new Error('unreachable')
+
+const choiceArgument: Licensing.AppInstall.AppInstall_CreateLicense = {
+  params: { meta: { values: {} } },
+}
+
+log.info({ contractId: target.contract_id }, 'exercising AppInstall_CreateLicense')
+const result = await ledger.postWithRetry('/v2/commands/submit-and-wait-for-transaction', {
+  commands: {
+    commandId: `happy-path-${Date.now()}`,
+    actAs: [PARTY_ID],
+    commands: [
+      {
+        ExerciseCommand: {
+          templateId: AppInstall.templateId,
+          contractId: target.contract_id,
+          choice: AppInstall.AppInstall_CreateLicense.choiceName,
+          choiceArgument,
+        },
+      },
+    ],
+  },
+  transactionFormat: {
+    // `verbose` is documented as optional but Canton's runtime rejects
+    // requests without it. Always include.
+    eventFormat: { filtersByParty: { [PARTY_ID]: {} }, verbose: false },
+    transactionShape: 'TRANSACTION_SHAPE_LEDGER_EFFECTS',
+  },
+})
+
+const createdEvent = result.transaction.events.find((ev) => 'CreatedEvent' in ev)
+const newLicenseCid =
+  createdEvent !== undefined && 'CreatedEvent' in createdEvent
+    ? createdEvent.CreatedEvent.contractId
+    : undefined
+log.info({ newLicenseCid }, 'created License')
+
+// 5. Confirm via PQS. `active(License)` should now include the new
+//    contract.
+if (newLicenseCid !== undefined) {
+  const { rows: licenses } = await pg.query<{ contract_id: string }>(
+    'SELECT contract_id FROM active($1) WHERE contract_id = $2',
+    [pqsTid(License.templateId), newLicenseCid],
+  )
+  log.info({ visibleInPqs: licenses.length === 1 }, 'PQS round-trip confirmation')
+}
+
+await pg.end()
+log.info('done')

--- a/quickstart/examples/node-happy-path/tsconfig.json
+++ b/quickstart/examples/node-happy-path/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/quickstart/integration-test/playwright.config.ts
+++ b/quickstart/integration-test/playwright.config.ts
@@ -44,6 +44,15 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
+
+    // Force *.localhost → 127.0.0.1 inside Chromium, bypassing the host
+    // resolver. macOS/Linux happily return ::1 for *.localhost via the
+    // myhostname/RFC6761 path; if any other process on the host is bound to
+    // ::1:3000 (e.g. an unrelated Next.js dev server), it hijacks the test.
+    // Docker's nginx publishes 127.0.0.1:3000 only — pinning to v4 fixes it.
+    launchOptions: {
+      args: ['--host-resolver-rules=MAP *.localhost 127.0.0.1'],
+    },
   },
 
   projects: [


### PR DESCRIPTION
## Summary

Adds a minimal Node.js example demonstrating Canton JSON Ledger API v2 + PQS end-to-end in ~135 lines, using `dpm codegen-js` typed bindings end-to-end so the choice argument shape is checked at compile time.

The example (`quickstart/examples/node-happy-path/`) shows, in one file:

1. Mint a shared-secret JWT for the Canton ledger API.
2. Build a `LedgerClient` from `@canton-network/core-ledger-client`.
3. Read active `AppInstall` contracts from the PQS Postgres replica.
4. Exercise `AppInstall_CreateLicense` via JSON Ledger API v2, with the choice argument typed against `Licensing.AppInstall.AppInstall_CreateLicense`.
5. Confirm the new `License` lands in PQS.

The README's gloss table points each thing the example skips at the package or pattern that would handle it in production code.

This directly answers #156 ("would have spared him hours") and #59 ("demonstrate the TypeScript ledger bindings, transcoder, and Canton JSON API v2 all working together").

Closes #156, #59.

## Why typed bindings matter here

Calling `dpm codegen-js` against the licensing DAR produces typed `Choice<T,C,R,K>` references and a generated `LicenseParams` shape (`{ meta: MetadataV1.Metadata }`, where `Metadata` is `{ values: TextMap }`).

Without those, common first-time mistakes are silent at compile time:

- `meta` written as `{ data: ... }` (the OpenAPI shape, not the wire shape)
- `params` misnamed
- `AppInstall_CreateLicense` misspelled

With them, all three are TS errors. The README explains this and the example sends `Licensing.AppInstall.AppInstall.templateId` directly to JSON v2 and (with the leading `#` stripped) to PQS — the only ledger-vs-PQS gotcha you cannot infer from OpenAPI.

## Bundled changes (kept minimal)

- **`integration-test/playwright.config.ts`** — passes `--host-resolver-rules=MAP *.localhost 127.0.0.1` to Chromium. Docker publishes `127.0.0.1:3000`; macOS / some Linux distros resolve `*.localhost` to `::1` first, so any host process bound to `::1:3000` can hijack the suite. Pinning to v4 makes the existing Playwright tests reproducible.
- **`nix/shell.nix`** — `nodejs_20` → `nodejs_22`, adds `nodePackages.pnpm`. Required to build and run the example.
- **`README.md` (root)** — small pointer to the example.

## What's intentionally not here

- A `keycloak-master-fix` sidecar to relax `sslRequired` on the master realm (a known issue for the integration-test suite on Keycloak 26.x). Security-sensitive enough to deserve its own review.
- A `DB_HOST_PORT` decoupling for postgres host port. That touches the existing `TEST_PORT` test-mode plumbing and should be reviewed separately.

A follow-up PR is being prepared to propose a fuller `quickstart/backend-node/` as a reference snapshot (opt-in via `BACKEND_FLAVOR=node`).

## Test plan

For the reviewer, on a fresh clone of this branch:

- [ ] `nix develop` (or install Node 22 + pnpm 9 manually).
- [ ] From `quickstart/`: `make setup` (choose shared-secret), `make build`, `make start`.
- [ ] Complete one onboarding flow in the UI so an `AppInstall` exists.
- [ ] From `quickstart/examples/node-happy-path/`: `pnpm codegen:daml && pnpm install && pnpm typecheck` should be clean.
- [ ] Run the example with `LEDGER_API_URL`, `PQS_DATABASE_URL`, `AUTH_SHARED_SECRET`, `APP_PROVIDER_PARTY_ID` set per the example's README; confirm the six log lines in the expected order.
- [ ] `make integration-test` (Java side) is unchanged.
- [ ] To verify typed bindings catch errors: temporarily change the choice argument to `{ params: { meta: { data: {} } } }`; `pnpm typecheck` should fail with `'data' does not exist in type 'Metadata'`.