### PR TITLE
uptick scribe and splice versions - splice and canton health check fix

### DIFF
--- a/quickstart/docker/modules/localnet/docker/canton/health-check.sh
+++ b/quickstart/docker/modules/localnet/docker/canton/health-check.sh
@@ -4,21 +4,17 @@
 
 set -eou pipefail
 
-# The canton image no longer ships grpcurl, so we probe the participants'
-# HTTP health server (monitoring.http-health-server) with curl instead.
-# curl -f makes a non-2xx response (i.e. an unhealthy node) fail the script.
-check() {
-  local port="$1"
-  echo "Checking ${port}"
-  curl -sf "http://localhost:${port}/health" > /dev/null
-}
-
+# The canton image ships neither curl nor grpcurl; grpc-health-probe is the only
+# probe available, so keep this in sync with Splice's own localnet health-check.
 if [ "$APP_USER_PROFILE" = "on" ]; then
-  check "2${CANTON_HTTP_HEALTHCHECK_PORT_SUFFIX}"
+  echo "Checking 2${CANTON_GRPC_HEALTHCHECK_PORT_SUFFIX}"
+  grpc-health-probe -addr="localhost:2${CANTON_GRPC_HEALTHCHECK_PORT_SUFFIX}"
 fi
 if [ "$APP_PROVIDER_PROFILE" = "on" ]; then
-  check "3${CANTON_HTTP_HEALTHCHECK_PORT_SUFFIX}"
+  echo "Checking 3${CANTON_GRPC_HEALTHCHECK_PORT_SUFFIX}"
+  grpc-health-probe -addr="localhost:3${CANTON_GRPC_HEALTHCHECK_PORT_SUFFIX}"
 fi
 if [ "$SV_PROFILE" = "on" ]; then
-  check "4${CANTON_HTTP_HEALTHCHECK_PORT_SUFFIX}"
+  echo "Checking 4${CANTON_GRPC_HEALTHCHECK_PORT_SUFFIX}"
+  grpc-health-probe -addr="localhost:4${CANTON_GRPC_HEALTHCHECK_PORT_SUFFIX}"
 fi

--- a/quickstart/docker/modules/localnet/docker/splice/health-check.sh
+++ b/quickstart/docker/modules/localnet/docker/splice/health-check.sh
@@ -4,14 +4,15 @@
 
 set -eou pipefail
 
+# The splice-app image does not ship curl; wget is the only HTTP client available.
 if [ "$APP_USER_PROFILE" = "on" ]; then
-  curl -f "http://localhost:2${VALIDATOR_ADMIN_API_PORT_SUFFIX}/api/validator/readyz"
+  wget --no-verbose --tries=1 --spider "http://localhost:2${VALIDATOR_ADMIN_API_PORT_SUFFIX}/api/validator/readyz"
 fi
 if [ "$APP_PROVIDER_PROFILE" = "on" ]; then
-  curl -f "http://localhost:3${VALIDATOR_ADMIN_API_PORT_SUFFIX}/api/validator/readyz"
+  wget --no-verbose --tries=1 --spider "http://localhost:3${VALIDATOR_ADMIN_API_PORT_SUFFIX}/api/validator/readyz"
 fi
 if [ "$SV_PROFILE" = "on" ]; then
-  curl -f "http://localhost:4${VALIDATOR_ADMIN_API_PORT_SUFFIX}/api/validator/readyz"
-  curl -f http://localhost:5012/api/scan/readyz
-  curl -f http://localhost:5014/api/sv/readyz
+  wget --no-verbose --tries=1 --spider "http://localhost:4${VALIDATOR_ADMIN_API_PORT_SUFFIX}/api/validator/readyz"
+  wget --no-verbose --tries=1 --spider http://localhost:5012/api/scan/readyz
+  wget --no-verbose --tries=1 --spider http://localhost:5014/api/sv/readyz
 fi


### PR DESCRIPTION
## Summary

The `canton` and `splice` LocalNet containers were failing their Docker health checks because the health-check scripts invoke HTTP/gRPC clients that are no longer present in the upgraded images. This PR points each script at a probe that the corresponding image actually ships.

- **canton**: `curl` against the HTTP health server → `grpc-health-probe` against the gRPC health server.
- **splice**: `curl -f` → `wget --spider` against the same readiness endpoints.

## Background

The probe tooling in these images has moved twice:

| | canton image | splice-app image |
|---|---|---|
| before the 3.5 upgrade | `grpcurl` | `curl` |
| after the 3.5 upgrade (#354) | `curl` (grpcurl was removed) | `curl` |
| this PR (Splice 0.6.11) | `grpc-health-probe` | `wget` |

The 3.5 upgrade moved the canton health check onto `curl` because `grpcurl` had been dropped from the image. The canton image that ships with Splice 0.6.11 contains neither `grpcurl` nor `curl` — `grpc-health-probe` is the only probe available — and the splice-app image no longer ships `curl` either. With `set -eou pipefail`, the missing binaries make the scripts exit non-zero, so both containers never become healthy and everything gated on `depends_on: service_healthy` stalls.

## Changes

### `quickstart/docker/modules/localnet/docker/canton/health-check.sh`

Probes each enabled participant with `grpc-health-probe` instead of `curl`, switching the target port back from `CANTON_HTTP_HEALTHCHECK_PORT_SUFFIX` to `CANTON_GRPC_HEALTHCHECK_PORT_SUFFIX`. Both ports are already defined in `localnet/env/common.env` and both health servers are already configured in the per-profile `conf/canton/*/app.conf`, so no configuration change is required. This restores the pre-3.5 behaviour of checking the gRPC health server, just with a different client, and keeps the script in sync with Splice's own LocalNet health check.

The local `check()` helper is dropped, since `grpc-health-probe` already exits non-zero on an unhealthy node.

### `quickstart/docker/modules/localnet/docker/splice/health-check.sh`

Replaces `curl -f <url>` with `wget --no-verbose --tries=1 --spider <url>` for the validator, scan, and SV `readyz` endpoints. `wget` exits non-zero on a non-2xx response, preserving the failure semantics that `curl -f` provided under `set -e`. `--tries=1` avoids `wget`'s default retry loop, leaving retry policy to the `healthcheck` block in `compose.yaml`.

Both scripts are mounted into their containers as `/app/health-check.sh` and run via `healthcheck.test` in `quickstart/docker/modules/localnet/compose.yaml`; that wiring is unchanged.
