### PR TITLE
fix(docs): move participant node inside optional box in high-level topology diagram

### DIFF
--- a/sdk/docs/user/002-topology.md
+++ b/sdk/docs/user/002-topology.md
@@ -16,13 +16,14 @@ flowchart TD
   subgraph user [App User]
     user-browser(Browser)
     user-auth(Auth)
-    user-participant(Participant)
 
     subgraph user-host ["Self Hosted Option"]
+      user-participant(Participant)
       user-ui(UI):::customNode
       user-backend("Backend"):::customNode
     end
     class user-host optional
+    class user-participant optional
     class user-ui optional
     class user-backend optional
 

--- a/sdk/docs/user/002-topology.md
+++ b/sdk/docs/user/002-topology.md
@@ -4,6 +4,7 @@ This document provides an overview of the Canton Network infrastructure and the 
 The diagrams below illustrate the relationships between Users, Providers, and the Super Validator, as well as the internal components that make up the system. 
 The focus of ``Canton Network Quickstart`` is to provide a development environment for App Providers - the provision of Super Validator infrastructure is auxiliary.
 
+
 ## High Level Structure
 
 This diagram summarizes the interaction between App Providers and App Users (organizations) through services and synchronization domains.


### PR DESCRIPTION
## Summary
The App User's Participant node was shown outside the 'Self Hosted Option' box in the high-level architecture diagram in , which was inconsistent with the App User Infrastructure diagram where it correctly appears inside the optional box.
## Changes
- Move  inside the  ('Self Hosted Option') subgraph in the high-level diagram.
- Add  so it gets the same optional styling as the other self-hosted nodes.